### PR TITLE
Add getter for StrorageApiHandler to StorageApiServer

### DIFF
--- a/web_server/storage_api_server.go
+++ b/web_server/storage_api_server.go
@@ -41,3 +41,8 @@ func (s *StorageApiServer) Start(port int) error {
 	fmt.Println("CTL-C to exit/stop Storage API server service")
 	return http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 }
+
+func (s *StorageApiServer) GetStorageApiHandler() *StorageApiHandler {
+	// Allow subprojects of Ubiquity to get a handle on the API handler so they can call Ubiquity functions internally
+	return s.storageApiHandler
+}


### PR DESCRIPTION
This is needed so subprojects of Ubiquity to get a handle on the API handler so they can call Ubiquity functions internally (e.g., ubiquity-cloudfoundry).

@midoblgsm for review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/54)
<!-- Reviewable:end -->
