### PR TITLE
fix for tcp connection not closed

### DIFF
--- a/remote/client.go
+++ b/remote/client.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/IBM/ubiquity/remote/mounter"
 	"github.com/IBM/ubiquity/utils"
+	"io/ioutil"
 )
 
 type remoteClient struct {
@@ -82,6 +83,8 @@ func (s *remoteClient) CreateVolume(createVolumeRequest resources.CreateVolumeRe
 		s.logger.Printf("Error in create volume remote call %s", err.Error())
 		return fmt.Errorf("Error in create volume remote call(http error)")
 	}
+	_, err = ioutil.ReadAll(response.Body)
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		s.logger.Printf("Error in create volume remote call %#v", response)
@@ -103,6 +106,8 @@ func (s *remoteClient) RemoveVolume(removeVolumeRequest resources.RemoveVolumeRe
 		s.logger.Printf("Error in remove volume remote call %#v", err)
 		return fmt.Errorf("Error in remove volume remote call")
 	}
+	_, err = ioutil.ReadAll(response.Body)
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		s.logger.Printf("Error in remove volume remote call %#v", response)
@@ -240,6 +245,8 @@ func (s *remoteClient) Detach(detachRequest resources.DetachRequest) error {
 		s.logger.Printf("Error in detach volume remote call %#v", err)
 		return fmt.Errorf("Error in detach volume remote call")
 	}
+	_, err = ioutil.ReadAll(response.Body)
+	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
 		s.logger.Printf("Error in detach volume remote call %#v", response)


### PR DESCRIPTION
The TCP connection wouldn't be reused and closed, and increased when had new actions.

Solution:
1. Clear the body of the response, so that the TCP connection can be reused
2. Close the TCP connection if it isn't be used after 90s idle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/110)
<!-- Reviewable:end -->
