### PR TITLE
Fix/increase locks sleep and run discover only in mount flow (not in unmount flow)

### DIFF
--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -187,11 +187,12 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 		line := scanner.Text()
 		if found {
 			matches := wwnRegexCompiled.FindStringSubmatch(line)
-			b.logger.Debug(fmt.Sprintf("%#v", matches))
 			if len(matches) != 2 {
+				b.logger.Debug(fmt.Sprintf("wrong line, too many matches in sg_inq output : %#v", matches))
 				return "", b.logger.ErrorRet(&noRegexWwnMatchInScsiInqError{ dev, line }, "failed")
 			}
 			wwn = matches[1]
+			b.logger.Debug(fmt.Sprintf("Found the expected Wwn [%s] in sg_inq.", wwn))
 			return wwn, nil
 		}
 		if regex.MatchString(line) {

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -65,7 +65,7 @@ func (b *blockDeviceUtils) Discover(volumeWwn string) (string, error) {
 	}
 
 	if dev == "" {
-		b.logger.Debug(fmt.Sprintf("using sg_inq to find wwn %s, since we did not find it using multipath -ll ", volumeWwn))
+		b.logger.Error(fmt.Sprintf("using sg_inq to find wwn %s, since we did not find it using multipath -ll ", volumeWwn))
 		dev, err = b.DiscoverBySgInq(string(outputBytes[:]), volumeWwn)
 		if err != nil {
 			b.logger.Error(fmt.Sprintf("wwn %s was not found using sg_inq on all mpath devices", volumeWwn))


### PR DESCRIPTION
1. increase sleep time on mpath lock and rescan lock from 100 to 500ms, so it will have less read IO while waiting for lock (since rescan usually take 1-2 seconds, so no need to have so many retries)

2. Fix wrong debug message in rescanLock (by mistake it was printed as mpathLock). Found by @danapython 

3. Do not run discover during rescan if the rescan was triggered during detach. becuase during detach the discover will always fail and its a waist of time and also it will start run sg_inq on each device which is also waist of time and few error in the log that are not relevant. SO move the discover during rescan only if rescan triggered for attach.  this is help us also to identify when we really have bad WWN show up in the multipath -ll.

4. Change message log from Debug to Error if discover doesn't find the WWN in multipath (usually it indicate the bad multipathing WWN in multipath -ll output. so its better to be in error level rather then debug level)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/167)
<!-- Reviewable:end -->
