### PR TITLE
Deep search (sg_inq) should continue to scan even if the sg_inq on one device failed

### DIFF
--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -113,7 +113,9 @@ func (b *blockDeviceUtils) DiscoverBySgInq(mpathOutput string, volumeWwn string)
 			mpathFullPath := b.mpathDevFullPath(dev)
 			wwn, err := b.GetWwnByScsiInq(mpathFullPath)
 			if err != nil {
-				return "", b.logger.ErrorRet(&volumeNotFoundError{volumeWwn}, "failed")
+				// we ignore errors and keep trying other devices.
+				b.logger.Debug(fmt.Sprintf("sg_inq comand faild on %s" ,err))
+				continue
 			}
 			if strings.ToLower(wwn) == strings.ToLower(volumeWwn){
 				return dev, nil


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/170)
<!-- Reviewable:end -->
