### PR TITLE
UB-624: flex log change design:

### DIFF
--- a/utils/logs/global_logger.go
+++ b/utils/logs/global_logger.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
 )
 
@@ -52,6 +53,15 @@ func GetLogLevelFromString(level string) Level {
 // It returns a function that clears the global logger.
 // If the global logger is already initialized InitFileLogger panics.
 func InitFileLogger(level Level, filePath string) func() {
+	_, err := os.Stat(filePath)
+	if os.IsNotExist(err) {
+		fileDir, _ := path.Split(filePath)
+		err := os.MkdirAll(fileDir, 0766)
+		if err != nil {
+			panic(fmt.Sprintf("failed to create log folder %v", err))
+		}
+	}
+	
 	logFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0640)
 	if err != nil {
 		panic(fmt.Sprintf("failed to init logger %v", err))


### PR DESCRIPTION
Signed-off-by: feihuang <feihuang@feihuangs-mbp.cn.ibm.com>

2. Option
change log to /var/logs
Mandatory ask for adding /var/logs for controller-manager
    Fei: we create /tmp/log/ubiquity in code, so don't need to ask customer to create this
Anyway daemonset upgrade yml is needed
Less coding, and no new go utility(no Legal)

Need to work with https://github.com/IBM/ubiquity-k8s/pull/164
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/182)
<!-- Reviewable:end -->
