### PR TITLE
Removing Specific Versions of ca-certificates and openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode 
 
 
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates=20161130-r2 openssl=1.0.2k-r0
+RUN apk --no-cache add ca-certificates openssl
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity/ubiquity .
 COPY --from=0 /go/src/github.com/IBM/ubiquity/LICENSE .


### PR DESCRIPTION
Hi,

This PR removes the specific version of ca-certificates and openssl, that are causing to break the image build. The testing has been done and results are attached in #183

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/184)
<!-- Reviewable:end -->
