### PR TITLE
Upgrade image to alpine 3.7. Also upgrade openssl and ca-certificates versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN glide up
 RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode external -extldflags "-static"' -installsuffix cgo -o ubiquity main.go
 
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates=20161130-r2 openssl=1.0.2k-r0
+FROM alpine:3.7
+RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2n-r0
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity/ubiquity .
 COPY --from=0 /go/src/github.com/IBM/ubiquity/LICENSE .


### PR DESCRIPTION
1. ubiquity base image in GA v1.0 was set to alpine:latest (back then it was alpine version 3.6).
   We should not use "latest" tag in dockerfile any more, so I set it to alpine:3.7 which is now the latest alpine version. So setting specific tag version and also upgrade to 3.7.

2. Upgrade alpine 3.7 requires to upgrade also the following packages in the docker image:
   ca-certificates  20161130-r2 --> 20171114-r0
   openssl          1.0.2k-r0   --> 1.0.2n-r0

Thanks Peeyush gupta @Pensu for indicating about the wrong dependencies with the latest alpine version.

**How to test**
1. Install ubiquity and then jump inside the ubiquity pod and check the new alpine version 
`#> kubectl exec -n ubiquity -it <POD> -- cat /etc/alpine-release`
In addition check the new packages version 
`#> kubectl exec -n ubiquity -it <POD> -- apk info -v | egrep "openssl|ca-cert`
(You can also use the google image tool for testing it)

2. Since we change some openssl and certificate, we also should check installing ubiquity with dedicate certificates and make sure it works well. 
(Automatic test should be developed for that)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/189)
<!-- Reviewable:end -->
