### PR TITLE
Fix for left over faulty multipath devices by preventing concurrent rescans during unmount and mount ops.

### DIFF
--- a/fakes/fake_block_device_mounter_utils.go
+++ b/fakes/fake_block_device_mounter_utils.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/IBM/ubiquity/remote/mounter/block_device_mounter_utils"
+	"github.com/nightlyone/lockfile"
 )
 
 type FakeBlockDeviceMounterUtils struct {
@@ -58,6 +59,15 @@ type FakeBlockDeviceMounterUtils struct {
 	}
 	unmountDeviceFlowReturnsOnCall map[int]struct {
 		result1 error
+	}
+	RescanFlockStub        func() lockfile.Lockfile
+	rescanFlockMutex       sync.RWMutex
+	rescanFlockArgsForCall []struct{}
+	rescanFlockReturns     struct {
+		result1 lockfile.Lockfile
+	}
+	rescanFlockReturnsOnCall map[int]struct {
+		result1 lockfile.Lockfile
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -263,6 +273,46 @@ func (fake *FakeBlockDeviceMounterUtils) UnmountDeviceFlowReturnsOnCall(i int, r
 	}{result1}
 }
 
+func (fake *FakeBlockDeviceMounterUtils) RescanFlock() lockfile.Lockfile {
+	fake.rescanFlockMutex.Lock()
+	ret, specificReturn := fake.rescanFlockReturnsOnCall[len(fake.rescanFlockArgsForCall)]
+	fake.rescanFlockArgsForCall = append(fake.rescanFlockArgsForCall, struct{}{})
+	fake.recordInvocation("RescanFlock", []interface{}{})
+	fake.rescanFlockMutex.Unlock()
+	if fake.RescanFlockStub != nil {
+		return fake.RescanFlockStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.rescanFlockReturns.result1
+}
+
+func (fake *FakeBlockDeviceMounterUtils) RescanFlockCallCount() int {
+	fake.rescanFlockMutex.RLock()
+	defer fake.rescanFlockMutex.RUnlock()
+	return len(fake.rescanFlockArgsForCall)
+}
+
+func (fake *FakeBlockDeviceMounterUtils) RescanFlockReturns(result1 lockfile.Lockfile) {
+	fake.RescanFlockStub = nil
+	fake.rescanFlockReturns = struct {
+		result1 lockfile.Lockfile
+	}{result1}
+}
+
+func (fake *FakeBlockDeviceMounterUtils) RescanFlockReturnsOnCall(i int, result1 lockfile.Lockfile) {
+	fake.RescanFlockStub = nil
+	if fake.rescanFlockReturnsOnCall == nil {
+		fake.rescanFlockReturnsOnCall = make(map[int]struct {
+			result1 lockfile.Lockfile
+		})
+	}
+	fake.rescanFlockReturnsOnCall[i] = struct {
+		result1 lockfile.Lockfile
+	}{result1}
+}
+
 func (fake *FakeBlockDeviceMounterUtils) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -274,6 +324,8 @@ func (fake *FakeBlockDeviceMounterUtils) Invocations() map[string][][]interface{
 	defer fake.discoverMutex.RUnlock()
 	fake.unmountDeviceFlowMutex.RLock()
 	defer fake.unmountDeviceFlowMutex.RUnlock()
+	fake.rescanFlockMutex.RLock()
+	defer fake.rescanFlockMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
+++ b/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
@@ -164,3 +164,9 @@ func (b *blockDeviceMounterUtils) RescanAll(withISCSI bool, wwn string, rescanFo
 func (b *blockDeviceMounterUtils) Discover(volumeWwn string, deepDiscovery bool) (string, error) {
 	return b.blockDeviceUtils.Discover(volumeWwn, deepDiscovery)
 }
+
+func (b *blockDeviceMounterUtils) RescanFlock() lockfile.Lockfile{
+	// Getter for rescanFlock to reuse the rescanFlock in other operations
+	// For this example, it uses for SCBE remote umount just before removing the device till the volume actually detach from the storage. To prevent rescan by concurrent attach operation during this window of time.
+	return b.rescanFlock
+}

--- a/remote/mounter/block_device_mounter_utils/resources.go
+++ b/remote/mounter/block_device_mounter_utils/resources.go
@@ -16,11 +16,14 @@
 
 package block_device_mounter_utils
 
+import "github.com/nightlyone/lockfile"
+
 //go:generate counterfeiter -o ../fakes/fake_block_device_mounter_utils.go . BlockDeviceMounterUtils
 type BlockDeviceMounterUtils interface {
 	RescanAll(withISCSI bool, wwn string, rescanForCleanUp bool) error
 	MountDeviceFlow(devicePath string, fsType string, mountPoint string) error
 	Discover(volumeWwn string, deepDiscovery bool) (string, error)
 	UnmountDeviceFlow(devicePath string) error
+	RescanFlock() lockfile.Lockfile
 }
 


### PR DESCRIPTION
There is a potential race between starting a POD and deleting a POD that may lead to faulty device on the operating system (left over device, which doesn't impact the host, but we still want to prevent it).

When deleting a pod the flex removes the multipath device and then unmap the volume from the host. But between these 2 operations there could be a race - if a rescan comes (for example a new POD created at the same time and as a result a multipath reload triggered) it could return back the deleted multipath devices and lead to faulty multipath device(because its a device that going to be unmapped, so it will stay on the OS as faulty device).

**How to fix:**
Preventing concurrent rescans during delete POD, in time-frame were the mpath device path removed but the volume still mapped to the host. (blockDeviceMounterUtils.UnmountDeviceFlow and just before ActionAfterDetach start)

**How to test**
Run concurrent create pod and delete pod at the same time. Do it many times in longevity. (of cause in XAVI automatic testing)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/190)
<!-- Reviewable:end -->
