### PR TITLE
Fix sg_inq parsing the WWN during the device discovery.

### DIFF
--- a/remote/mounter/block_device_utils/block_device_utils_test.go
+++ b/remote/mounter/block_device_utils/block_device_utils_test.go
@@ -142,32 +142,6 @@ var _ = Describe("block_device_utils_test", func() {
 			Expect(cmd).To(Equal("sg_inq"))
 			Expect(args).To(Equal([]string{"-p",  "0x83", "/dev/mapper/mpath"}))
 		})
-                It("Discover returns path for volume on z systems", func() {
-                        volumeId := "0x6001738cfc9035eb0000000000cea5f6"
-                        result := "mpath"
-                        inq_result := fmt.Sprintf(`VPD INQUIRY: Device Identification page
-                                                        Designation descriptor number 1, descriptor length: 20
-                                                        designator_type: NAA,  code_set: Binary
-                                                        associated with the addressed logical unit
-                                                        NAA 6, IEEE Company_id: 0x1738
-                                                        Vendor Specific Identifier: 0xcfc9035eb
-                                                        Vendor Specific Extension Identifier: 0x6443003d
-                                                        [%s]`, volumeId)
-                        fakeExec.ExecuteReturnsOnCall(0, []byte(fmt.Sprintf("%s (%s) dm-1", result, volumeId)),
-                                nil)
-                        fakeExec.ExecuteWithTimeoutReturns([]byte(fmt.Sprintf("%s", inq_result)), nil) // for getWwnByScsiInq
-                        mpath, err := bdUtils.Discover(strings.TrimPrefix(volumeId, "0x"), true)
-                        Expect(err).ToNot(HaveOccurred())
-                        Expect(mpath).To(Equal("/dev/mapper/" + result))
-                        Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
-                        Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
-                        cmd, args := fakeExec.ExecuteArgsForCall(0)
-                        Expect(cmd).To(Equal("multipath"))
-                        Expect(args).To(Equal([]string{"-ll"}))
-                        _, cmd, args = fakeExec.ExecuteWithTimeoutArgsForCall(0)
-                        Expect(cmd).To(Equal("sg_inq"))
-                        Expect(args).To(Equal([]string{"-p",  "0x83", "/dev/mapper/mpath"}))
-                })
 		It("Discover fails if multipath command is missing", func() {
 			volumeId := "volume-id"
 			fakeExec.IsExecutableReturns(cmdErr)
@@ -307,6 +281,26 @@ mpathhb (36001738cfc9035eb0000000000cea###) dm-3 ##,##
 			Expect(cmd).To(Equal("sg_inq"))
 			Expect(args).To(Equal([]string{"-p",  "0x83", dev}))
 		})
+                It("should return wwn for mpath device on zLinux output", func() {
+                        dev := "dev"
+                        expecedWwn := "0x6001738cfc9035eb0000000000AAAAAA"
+                        result := fmt.Sprintf(`VPD INQUIRY: Device Identification page
+                                                        Designation descriptor number 1, descriptor length: 20
+                                                        designator_type: NAA,  code_set: Binary
+                                                        associated with the addressed logical unit
+                                                        NAA 6, IEEE Company_id: 0x1738
+                                                        Vendor Specific Identifier: 0xcfc9035eb
+                                                        Vendor Specific Extension Identifier: 0xcea5f6
+                                                        [%s]`, expecedWwn)
+                        fakeExec.ExecuteWithTimeoutReturns([]byte(fmt.Sprintf("%s", result)), nil)
+                        wwn, err := bdUtils.GetWwnByScsiInq(dev)
+                        Expect(err).ToNot(HaveOccurred())
+                        Expect(wwn).To(Equal(strings.TrimPrefix(expecedWwn, "0x")))
+                        Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
+                        _, cmd, args := fakeExec.ExecuteWithTimeoutArgsForCall(0)
+                        Expect(cmd).To(Equal("sg_inq"))
+                        Expect(args).To(Equal([]string{"-p",  "0x83", dev}))
+                })
 		It("should not find wwn for device", func() {
 			dev := "dev"
 			expecedWwn := "6001738cfc9035eb0000000000AAAAAA"

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -185,8 +185,10 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 	if err != nil {
 		return "", b.logger.ErrorRet(err, "failed")
 	}
-        /* x86 systems returns 'Vendor Specific Identifier Extension' and zLinux systems
-        return Vendor Specific Extension Identifier. */
+        /*
+           sg_inq on device NAA6 returns "Vendor Specific Identifier Extension"
+           sg_inq on device EUI-64 returns "Vendor Specific Extension Identifier".
+        */
 	pattern := "(?i)" + "Vendor Specific (Identifier Extension|Extension Identifier):"
 	scanner := bufio.NewScanner(strings.NewReader(string(outputBytes[:])))
 	regex, err := regexp.Compile(pattern)

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -187,7 +187,7 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 	}
         /* x86 systems returns 'Vendor Specific Identifier Extension' and zLinux systems
         return Vendor Specific Extension Identifier. */
-	pattern := "(?i)" + "Vendor Specific (Identifier Extension|Extension Identifier):"
+	pattern := "(?i)" + "Vendor Specific (Identifier Extension|Extension Identifier)"
 	scanner := bufio.NewScanner(strings.NewReader(string(outputBytes[:])))
 	regex, err := regexp.Compile(pattern)
 	if err != nil {
@@ -207,6 +207,7 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 			b.logger.Debug(fmt.Sprintf("Found the expected Wwn [%s] in sg_inq.", wwn))
 			return wwn, nil
 		}
+                b.logger.Debug(fmt.Sprintf("line: %s", line))
 		if regex.MatchString(line) {
 			found = true
 			// its one line after "Vendor Specific Identifier Extension:" line which should contain the WWN

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -185,7 +185,7 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 	if err != nil {
 		return "", b.logger.ErrorRet(err, "failed")
 	}
-	pattern := "(?i)" + "Vendor Specific Identifier Extension:"
+	pattern := "(?i)" + "Vendor Specific (Identifier|Extension) (Identifier|Extension):"
 	scanner := bufio.NewScanner(strings.NewReader(string(outputBytes[:])))
 	regex, err := regexp.Compile(pattern)
 	if err != nil {

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -187,7 +187,7 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 	}
         /* x86 systems returns 'Vendor Specific Identifier Extension' and zLinux systems
         return Vendor Specific Extension Identifier. */
-	pattern := "(?i)" + "Vendor Specific (Identifier Extension|Extension Identifier)"
+	pattern := "(?i)" + "Vendor Specific (Identifier Extension|Extension Identifier):"
 	scanner := bufio.NewScanner(strings.NewReader(string(outputBytes[:])))
 	regex, err := regexp.Compile(pattern)
 	if err != nil {
@@ -207,7 +207,6 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 			b.logger.Debug(fmt.Sprintf("Found the expected Wwn [%s] in sg_inq.", wwn))
 			return wwn, nil
 		}
-                b.logger.Debug(fmt.Sprintf("line: %s", line))
 		if regex.MatchString(line) {
 			found = true
 			// its one line after "Vendor Specific Identifier Extension:" line which should contain the WWN

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -185,7 +185,9 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 	if err != nil {
 		return "", b.logger.ErrorRet(err, "failed")
 	}
-	pattern := "(?i)" + "Vendor Specific (Identifier|Extension) (Identifier|Extension):"
+        /* x86 systems returns 'Vendor Specific Identifier Extension' and zLinux systems
+        return Vendor Specific Extension Identifier. */
+	pattern := "(?i)" + "Vendor Specific (Identifier Extension|Extension Identifier):"
 	scanner := bufio.NewScanner(strings.NewReader(string(outputBytes[:])))
 	regex, err := regexp.Compile(pattern)
 	if err != nil {


### PR DESCRIPTION
Internal ticket UB-1030.

Validate the WWN of the discovered device done by sg_inq. But we have a bug there that the parsing sg_inq output is not working well for XIV because different outline of the sg_inq output.

(was found while testing Ubiquity on zLinux)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/195)
<!-- Reviewable:end -->
