### PR TITLE
update openssl to 1.0.2o-r0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode 
 
 
 FROM alpine:3.7
-RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2n-r0
+RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2o-r0
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity/ubiquity .
 COPY --from=0 /go/src/github.com/IBM/ubiquity/LICENSE .

--- a/scripts/images_verification/ubiquity_image_verification/ubiquity_image_command_test.yaml
+++ b/scripts/images_verification/ubiquity_image_verification/ubiquity_image_command_test.yaml
@@ -1,7 +1,7 @@
 schemaVersion: '2.0.0'
 
 commandTests:
-  # check that alpine version is 3.7.0 and ca-certificates version 20171114-r0 and openssl version 1.0.2n-r0 packages installed
+  # check that alpine version is 3.7.0 and ca-certificates version 20171114-r0 and openssl version 1.0.2o-r0 packages installed
   - name: "alpine version 3.7.0"
     command: "cat"
     args: ["/etc/alpine-release"]
@@ -10,7 +10,7 @@ commandTests:
     command: "apk"
     args: ["info", "-vv"]
     expectedOutput: ["ca-certificates-20171114-r0"]
-  - name: "openssl version 1.0.2n-r0 package"
+  - name: "openssl version 1.0.2o-r0 package"
     command: "apk"
     args: ["info", "-vv"]
-    expectedOutput: ["openssl-1.0.2n-r0"]
+    expectedOutput: ["openssl-1.0.2o-r0"]


### PR DESCRIPTION
openssl-1.0.2o is available since 27-Mar-2018 and is available for all relevant platforms. openssl-1.0.2n is not available on ppc64le.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/205)
<!-- Reviewable:end -->
