### PR TITLE
Mount flow should fail to mount if the mountpoint is already in-use.

### DIFF
--- a/fakes/fake_block_device_utils.go
+++ b/fakes/fake_block_device_utils.go
@@ -143,6 +143,21 @@ type FakeBlockDeviceUtils struct {
 		result2 []string
 		result3 error
 	}
+	IsDirIsAMountPointStub        func(dirPath string) (bool, []string, error)
+	isDirIsAMountPointMutex       sync.RWMutex
+	isDirIsAMountPointArgsForCall []struct {
+		dirPath string
+	}
+	isDirIsAMountPointReturns struct {
+		result1 bool
+		result2 []string
+		result3 error
+	}
+	isDirIsAMountPointReturnsOnCall map[int]struct {
+		result1 bool
+		result2 []string
+		result3 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -689,6 +704,60 @@ func (fake *FakeBlockDeviceUtils) IsDeviceMountedReturnsOnCall(i int, result1 bo
 	}{result1, result2, result3}
 }
 
+func (fake *FakeBlockDeviceUtils) IsDirIsAMountPoint(dirPath string) (bool, []string, error) {
+	fake.isDirIsAMountPointMutex.Lock()
+	ret, specificReturn := fake.isDirIsAMountPointReturnsOnCall[len(fake.isDirIsAMountPointArgsForCall)]
+	fake.isDirIsAMountPointArgsForCall = append(fake.isDirIsAMountPointArgsForCall, struct {
+		dirPath string
+	}{dirPath})
+	fake.recordInvocation("IsDirIsAMountPoint", []interface{}{dirPath})
+	fake.isDirIsAMountPointMutex.Unlock()
+	if fake.IsDirIsAMountPointStub != nil {
+		return fake.IsDirIsAMountPointStub(dirPath)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fake.isDirIsAMountPointReturns.result1, fake.isDirIsAMountPointReturns.result2, fake.isDirIsAMountPointReturns.result3
+}
+
+func (fake *FakeBlockDeviceUtils) IsDirIsAMountPointCallCount() int {
+	fake.isDirIsAMountPointMutex.RLock()
+	defer fake.isDirIsAMountPointMutex.RUnlock()
+	return len(fake.isDirIsAMountPointArgsForCall)
+}
+
+func (fake *FakeBlockDeviceUtils) IsDirIsAMountPointArgsForCall(i int) string {
+	fake.isDirIsAMountPointMutex.RLock()
+	defer fake.isDirIsAMountPointMutex.RUnlock()
+	return fake.isDirIsAMountPointArgsForCall[i].dirPath
+}
+
+func (fake *FakeBlockDeviceUtils) IsDirIsAMountPointReturns(result1 bool, result2 []string, result3 error) {
+	fake.IsDirIsAMountPointStub = nil
+	fake.isDirIsAMountPointReturns = struct {
+		result1 bool
+		result2 []string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeBlockDeviceUtils) IsDirIsAMountPointReturnsOnCall(i int, result1 bool, result2 []string, result3 error) {
+	fake.IsDirIsAMountPointStub = nil
+	if fake.isDirIsAMountPointReturnsOnCall == nil {
+		fake.isDirIsAMountPointReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 []string
+			result3 error
+		})
+	}
+	fake.isDirIsAMountPointReturnsOnCall[i] = struct {
+		result1 bool
+		result2 []string
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeBlockDeviceUtils) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -714,6 +783,8 @@ func (fake *FakeBlockDeviceUtils) Invocations() map[string][][]interface{} {
 	defer fake.umountFsMutex.RUnlock()
 	fake.isDeviceMountedMutex.RLock()
 	defer fake.isDeviceMountedMutex.RUnlock()
+	fake.isDirIsAMountPointMutex.RLock()
+	defer fake.isDirIsAMountPointMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/fakes/fake_block_device_utils.go
+++ b/fakes/fake_block_device_utils.go
@@ -143,17 +143,17 @@ type FakeBlockDeviceUtils struct {
 		result2 []string
 		result3 error
 	}
-	IsDirIsAMountPointStub        func(dirPath string) (bool, []string, error)
-	isDirIsAMountPointMutex       sync.RWMutex
-	isDirIsAMountPointArgsForCall []struct {
+	IsDirAMountPointStub        func(dirPath string) (bool, []string, error)
+	isDirAMountPointMutex       sync.RWMutex
+	isDirAMountPointArgsForCall []struct {
 		dirPath string
 	}
-	isDirIsAMountPointReturns struct {
+	isDirAMountPointReturns struct {
 		result1 bool
 		result2 []string
 		result3 error
 	}
-	isDirIsAMountPointReturnsOnCall map[int]struct {
+	isDirAMountPointReturnsOnCall map[int]struct {
 		result1 bool
 		result2 []string
 		result3 error
@@ -704,54 +704,54 @@ func (fake *FakeBlockDeviceUtils) IsDeviceMountedReturnsOnCall(i int, result1 bo
 	}{result1, result2, result3}
 }
 
-func (fake *FakeBlockDeviceUtils) IsDirIsAMountPoint(dirPath string) (bool, []string, error) {
-	fake.isDirIsAMountPointMutex.Lock()
-	ret, specificReturn := fake.isDirIsAMountPointReturnsOnCall[len(fake.isDirIsAMountPointArgsForCall)]
-	fake.isDirIsAMountPointArgsForCall = append(fake.isDirIsAMountPointArgsForCall, struct {
+func (fake *FakeBlockDeviceUtils) IsDirAMountPoint(dirPath string) (bool, []string, error) {
+	fake.isDirAMountPointMutex.Lock()
+	ret, specificReturn := fake.isDirAMountPointReturnsOnCall[len(fake.isDirAMountPointArgsForCall)]
+	fake.isDirAMountPointArgsForCall = append(fake.isDirAMountPointArgsForCall, struct {
 		dirPath string
 	}{dirPath})
-	fake.recordInvocation("IsDirIsAMountPoint", []interface{}{dirPath})
-	fake.isDirIsAMountPointMutex.Unlock()
-	if fake.IsDirIsAMountPointStub != nil {
-		return fake.IsDirIsAMountPointStub(dirPath)
+	fake.recordInvocation("IsDirAMountPoint", []interface{}{dirPath})
+	fake.isDirAMountPointMutex.Unlock()
+	if fake.IsDirAMountPointStub != nil {
+		return fake.IsDirAMountPointStub(dirPath)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.isDirIsAMountPointReturns.result1, fake.isDirIsAMountPointReturns.result2, fake.isDirIsAMountPointReturns.result3
+	return fake.isDirAMountPointReturns.result1, fake.isDirAMountPointReturns.result2, fake.isDirAMountPointReturns.result3
 }
 
-func (fake *FakeBlockDeviceUtils) IsDirIsAMountPointCallCount() int {
-	fake.isDirIsAMountPointMutex.RLock()
-	defer fake.isDirIsAMountPointMutex.RUnlock()
-	return len(fake.isDirIsAMountPointArgsForCall)
+func (fake *FakeBlockDeviceUtils) IsDirAMountPointCallCount() int {
+	fake.isDirAMountPointMutex.RLock()
+	defer fake.isDirAMountPointMutex.RUnlock()
+	return len(fake.isDirAMountPointArgsForCall)
 }
 
-func (fake *FakeBlockDeviceUtils) IsDirIsAMountPointArgsForCall(i int) string {
-	fake.isDirIsAMountPointMutex.RLock()
-	defer fake.isDirIsAMountPointMutex.RUnlock()
-	return fake.isDirIsAMountPointArgsForCall[i].dirPath
+func (fake *FakeBlockDeviceUtils) IsDirAMountPointArgsForCall(i int) string {
+	fake.isDirAMountPointMutex.RLock()
+	defer fake.isDirAMountPointMutex.RUnlock()
+	return fake.isDirAMountPointArgsForCall[i].dirPath
 }
 
-func (fake *FakeBlockDeviceUtils) IsDirIsAMountPointReturns(result1 bool, result2 []string, result3 error) {
-	fake.IsDirIsAMountPointStub = nil
-	fake.isDirIsAMountPointReturns = struct {
+func (fake *FakeBlockDeviceUtils) IsDirAMountPointReturns(result1 bool, result2 []string, result3 error) {
+	fake.IsDirAMountPointStub = nil
+	fake.isDirAMountPointReturns = struct {
 		result1 bool
 		result2 []string
 		result3 error
 	}{result1, result2, result3}
 }
 
-func (fake *FakeBlockDeviceUtils) IsDirIsAMountPointReturnsOnCall(i int, result1 bool, result2 []string, result3 error) {
-	fake.IsDirIsAMountPointStub = nil
-	if fake.isDirIsAMountPointReturnsOnCall == nil {
-		fake.isDirIsAMountPointReturnsOnCall = make(map[int]struct {
+func (fake *FakeBlockDeviceUtils) IsDirAMountPointReturnsOnCall(i int, result1 bool, result2 []string, result3 error) {
+	fake.IsDirAMountPointStub = nil
+	if fake.isDirAMountPointReturnsOnCall == nil {
+		fake.isDirAMountPointReturnsOnCall = make(map[int]struct {
 			result1 bool
 			result2 []string
 			result3 error
 		})
 	}
-	fake.isDirIsAMountPointReturnsOnCall[i] = struct {
+	fake.isDirAMountPointReturnsOnCall[i] = struct {
 		result1 bool
 		result2 []string
 		result3 error
@@ -783,8 +783,8 @@ func (fake *FakeBlockDeviceUtils) Invocations() map[string][][]interface{} {
 	defer fake.umountFsMutex.RUnlock()
 	fake.isDeviceMountedMutex.RLock()
 	defer fake.isDeviceMountedMutex.RUnlock()
-	fake.isDirIsAMountPointMutex.RLock()
-	defer fake.isDirIsAMountPointMutex.RUnlock()
+	fake.isDirAMountPointMutex.RLock()
+	defer fake.isDirAMountPointMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
+++ b/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
@@ -90,7 +90,7 @@ func (b *blockDeviceMounterUtils) MountDeviceFlow(devicePath string, fsType stri
 		return b.logger.ErrorRet(&DeviceAlreadyMountedToWrongMountpoint{devicePath, mountPoint}, "fail")
 	} else {
 		// Check if mountpoint directory is not already mounted to un expected device. If so raise error to prevent double mounting.
-		isMounted, devicesRefs, err := b.blockDeviceUtils.IsDirIsAMountPoint(mountPoint)
+		isMounted, devicesRefs, err := b.blockDeviceUtils.IsDirAMountPoint(mountPoint)
 		if err != nil {
 			return b.logger.ErrorRet(err, "fail to identify if mountpoint dir is actually mounted")
 		}

--- a/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
+++ b/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
@@ -89,6 +89,17 @@ func (b *blockDeviceMounterUtils) MountDeviceFlow(devicePath string, fsType stri
 		// In case device mounted but to different mountpoint as expected we fail with error. # TODO we may support it in the future after allow the umount flow to umount by mountpoint and not by device path.
 		return b.logger.ErrorRet(&DeviceAlreadyMountedToWrongMountpoint{devicePath, mountPoint}, "fail")
 	} else {
+		// Check if mountpoint directory is not already mounted to un expected device. If so raise error to prevent double mounting.
+		isMounted, devicesRefs, err := b.blockDeviceUtils.IsDirIsAMountPoint(mountPoint)
+		if err != nil {
+			return b.logger.ErrorRet(err, "fail to identify if mountpoint dir is actually mounted")
+		}
+
+		if isMounted {
+			return b.logger.ErrorRet(&DirPathAlreadyMountedToWrongDevice{
+				mountPoint: mountPoint, expectedDevice: devicePath, unexpectedDevicesRefs: devicesRefs},
+				"fail")
+		}
 		if err = b.blockDeviceUtils.MountFs(devicePath, mountPoint); err != nil {
 			return b.logger.ErrorRet(err, "MountFs failed")
 		}

--- a/remote/mounter/block_device_mounter_utils/errors.go
+++ b/remote/mounter/block_device_mounter_utils/errors.go
@@ -26,3 +26,14 @@ type DeviceAlreadyMountedToWrongMountpoint struct {
 func (e *DeviceAlreadyMountedToWrongMountpoint) Error() string {
 	return fmt.Sprintf("Device is already mounted but to unexpected mountpoint. device=[%s], mountpoint=[%s]", e.device, e.mountpoint)
 }
+
+type DirPathAlreadyMountedToWrongDevice struct {
+	mountPoint            string
+	expectedDevice        string
+	unexpectedDevicesRefs []string
+}
+
+func (e *DirPathAlreadyMountedToWrongDevice) Error() string {
+	return fmt.Sprintf("Directory=[%s] is already a mountpoint but on the unexpected devices=%#v (expected only on device=[%s])",
+		e.mountPoint, e.unexpectedDevicesRefs, e.expectedDevice)
+}

--- a/remote/mounter/block_device_mounter_utils/errors.go
+++ b/remote/mounter/block_device_mounter_utils/errors.go
@@ -34,6 +34,6 @@ type DirPathAlreadyMountedToWrongDevice struct {
 }
 
 func (e *DirPathAlreadyMountedToWrongDevice) Error() string {
-	return fmt.Sprintf("Directory=[%s] is already a mountpoint but on the unexpected devices=%#v (expected only on device=[%s])",
+	return fmt.Sprintf("[%s] directory is already a mountpoint but to unexpected devices=%#v (expected mountpoint only on device=[%s])",
 		e.mountPoint, e.unexpectedDevicesRefs, e.expectedDevice)
 }

--- a/remote/mounter/block_device_utils/fs.go
+++ b/remote/mounter/block_device_utils/fs.go
@@ -168,7 +168,7 @@ func (b *blockDeviceUtils) IsDeviceMounted(devPath string) (bool, []string, erro
 	}
 }
 
-func (b *blockDeviceUtils) IsDirIsAMountPoint(dirPath string) (bool, []string, error) {
+func (b *blockDeviceUtils) IsDirAMountPoint(dirPath string) (bool, []string, error) {
 	/*
 		   This function check if a given directory is not an active mountpoint (by pars the mount output).
 		   Return Values:

--- a/remote/mounter/block_device_utils/fs.go
+++ b/remote/mounter/block_device_utils/fs.go
@@ -107,25 +107,41 @@ func (b *blockDeviceUtils) UmountFs(mpoint string) error {
 	return nil
 }
 
+func (b *blockDeviceUtils) executeMountCmdToViewMountpoints() ([]byte, error) {
+	/*
+	   Check if mount command exist (if not return error commandNotFoundError)
+	   then trigger the mount command with no params (if failed return error commandExecuteError)
+	   and return the output as []byte.
+	*/
+
+	defer b.logger.Trace(logs.DEBUG)()
+	mountCmd := "mount"
+	if err := b.exec.IsExecutable(mountCmd); err != nil {
+		return nil, b.logger.ErrorRet(&commandNotFoundError{mountCmd, err}, "failed")
+	}
+
+	outputBytes, err := b.exec.ExecuteWithTimeout(TimeoutMilisecondMountCmdIsDeviceMounted, mountCmd, nil)
+	if err != nil {
+		return nil, b.logger.ErrorRet(&commandExecuteError{mountCmd, err}, "failed")
+	}
+
+	return outputBytes, nil
+}
+
 func (b *blockDeviceUtils) IsDeviceMounted(devPath string) (bool, []string, error) {
 	/*
 	   true, mountpoints, nil  : If device is mounted (check via pars the mount output)
 	   false, nil, nil : if device is not mounted
 	   false, nil, err : if failed to discover
 	*/
-
 	defer b.logger.Trace(logs.DEBUG)()
-	mountCmd := "mount"
-	if err := b.exec.IsExecutable(mountCmd); err != nil {
-		return false, nil, b.logger.ErrorRet(&commandNotFoundError{mountCmd, err}, "failed")
-	}
 
-	outputBytes, err := b.exec.ExecuteWithTimeout(TimeoutMilisecondMountCmdIsDeviceMounted, mountCmd, nil)
+	outputBytes, err := b.executeMountCmdToViewMountpoints()
 	if err != nil {
-		return false, nil, b.logger.ErrorRet(&commandExecuteError{mountCmd, err}, "failed")
+		return false, nil, err
 	}
 	scanner := bufio.NewScanner(strings.NewReader(string(outputBytes[:])))
-	pattern := fmt.Sprint("^" + devPath + `\son\s(.*?)\s`)
+	pattern := fmt.Sprint("^" + devPath + `\son\s(.*?)\s`) // catch mountpath if devPath found.
 	regex, err := regexp.Compile(pattern)
 	if err != nil {
 		return false, nil, b.logger.ErrorRet(err, "failed")
@@ -149,6 +165,49 @@ func (b *blockDeviceUtils) IsDeviceMounted(devPath string) (bool, []string, erro
 	} else {
 		b.logger.Debug("Found mpath device as mounted device on mountpoints", logs.Args{{"mpath", devPath}, {"num_mountpoint", len(mounts)}, {"mountpoints", mounts}})
 		return true, mounts, nil
+	}
+}
+
+func (b *blockDeviceUtils) IsDirIsAMountPoint(dirPath string) (bool, []string, error) {
+	/*
+		   This function check if a given directory is not an active mountpoint (by pars the mount output).
+		   Return Values:
+			   true, devices, nil  : If dir is a mounted.
+			   false, nil, nil : if dir is not a mountpoint
+			   false, nil, err : if failed to discover
+	*/
+
+	defer b.logger.Trace(logs.DEBUG)()
+	outputBytes, err := b.executeMountCmdToViewMountpoints()
+	if err != nil {
+		return false, nil, err
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(string(outputBytes[:])))
+	pattern := fmt.Sprint(`^(.*?)\son\s` + dirPath + `\s`) // catch devicePath if dirPath found.
+	regex, err := regexp.Compile(pattern)
+	if err != nil {
+		return false, nil, b.logger.ErrorRet(err, "failed")
+	}
+	var devices []string
+	for scanner.Scan() {
+		line := scanner.Text()
+		matches := regex.FindStringSubmatch(line)
+		if len(matches) != 2 {
+			// not found regex in this line, so continue to next line.
+			continue
+		}
+
+		b.logger.Debug("Found dirPath as mountpoint to device", logs.Args{{"device", matches[1]}, {"mountpoint", dirPath}, {"mountLine", line}})
+		devices = append(devices, matches[1])
+	}
+
+	if len(devices) == 0 {
+		b.logger.Debug("Not found dirPath as mountpoint", logs.Args{{"dirPath", dirPath}})
+		return false, nil, nil
+	} else {
+		b.logger.Debug("Found dirPath as mountpoint on the following devices", logs.Args{{"dirPath", dirPath}, {"num_devices", len(devices)}, {"devices", devices}})
+		return true, devices, nil
 	}
 }
 

--- a/remote/mounter/block_device_utils/resources.go
+++ b/remote/mounter/block_device_utils/resources.go
@@ -36,4 +36,5 @@ type BlockDeviceUtils interface {
 	MountFs(mpath string, mpoint string) error
 	UmountFs(mpoint string) error
 	IsDeviceMounted(devPath string) (bool, []string, error)
+	IsDirIsAMountPoint(dirPath string) (bool, []string, error)
 }

--- a/remote/mounter/block_device_utils/resources.go
+++ b/remote/mounter/block_device_utils/resources.go
@@ -36,5 +36,5 @@ type BlockDeviceUtils interface {
 	MountFs(mpath string, mpoint string) error
 	UmountFs(mpoint string) error
 	IsDeviceMounted(devPath string) (bool, []string, error)
-	IsDirIsAMountPoint(dirPath string) (bool, []string, error)
+	IsDirAMountPoint(dirPath string) (bool, []string, error)
 }


### PR DESCRIPTION
This PR is for fixing a bug that @danare found in PR #196 (internal issue UB-1230).

Flex mount CLI must prevent mounting a device if the mountpoint is already in used by other device, in order to prevent double mounting on the same directory. 

So this PR fix it and check during the mount flow if the given mountpoint is already in-used (already mounted by other device). If its already mounted to a different device, then error will be raised
"[%s] directory is already a mountpoint but to unexpected devices=%#v (expected mountpoint only on device=[%s])"

**How to test:**
1. Create 2 PVCs (PVC1 & PVC2) and check what is the PV1 WWN (will be used in step 3)
2. Manually create and map PV2 on node1.
3. Manually discover the PV2 the device on the node1 and mkfs and mount it to a directory /ubiquity/<PV1 WWN>  (create the directory in advance)
3. Create Pod on node1 that uses PVC1, the creation of the pod should fail(Container creating) due to the error mentioned above.
4. Now manually unmount PVC2 from node1, unmap and clean its device from node1. Then after after few minutes (k8s flex scheduling) should start the POD successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/212)
<!-- Reviewable:end -->
