### PR TITLE
Fix error message in mounter_utils (per Dana review UB-1230) and fix fake file

### DIFF
--- a/remote/mounter/block_device_mounter_utils/block_device_utils_mounter_test.go
+++ b/remote/mounter/block_device_mounter_utils/block_device_utils_mounter_test.go
@@ -135,25 +135,25 @@ var _ = Describe("block_device_mounter_utils_test", func() {
 
 		})
 
-		It("should fail if IsDirIsAMountPoint failed", func() {
+		It("should fail if IsDirAMountPoint failed", func() {
 			fakeBlockDeviceUtils.CheckFsReturns(true, nil)
 			fakeBlockDeviceUtils.IsDeviceMountedReturns(false, nil, nil)
-			fakeBlockDeviceUtils.IsDirIsAMountPointReturns(false, nil, callErr)
+			fakeBlockDeviceUtils.IsDirAMountPointReturns(false, nil, callErr)
 			err = blockDeviceMounterUtils.MountDeviceFlow("fake_device", "fake_fstype", "fake_mountp")
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(callErr))
-			Expect(fakeBlockDeviceUtils.IsDirIsAMountPointCallCount()).To(Equal(1))
+			Expect(fakeBlockDeviceUtils.IsDirAMountPointCallCount()).To(Equal(1))
 		})
 
 		It("should fail to mount if mountpoint is already mounted to wrong device", func() {
 			fakeBlockDeviceUtils.CheckFsReturns(true, nil)
 			fakeBlockDeviceUtils.IsDeviceMountedReturns(false, nil, nil)
-			fakeBlockDeviceUtils.IsDirIsAMountPointReturns(true, nil, nil)
+			fakeBlockDeviceUtils.IsDirAMountPointReturns(true, []string{"/dev/mapper/mpathvfake1", "/dev/mapper/mpathvfake2"}, nil)
 			err = blockDeviceMounterUtils.MountDeviceFlow("fake_device", "fake_fstype", "fake_mountp")
 			Expect(err).To(HaveOccurred())
 			_, ok := err.(*block_device_mounter_utils.DirPathAlreadyMountedToWrongDevice)
 			Expect(ok).To(Equal(true))
-			Expect(fakeBlockDeviceUtils.IsDirIsAMountPointCallCount()).To(Equal(1))
+			Expect(fakeBlockDeviceUtils.IsDirAMountPointCallCount()).To(Equal(1))
 			Expect(fakeBlockDeviceUtils.MountFsCallCount()).To(Equal(0))
 
 		})
@@ -162,7 +162,7 @@ var _ = Describe("block_device_mounter_utils_test", func() {
 			fakeBlockDeviceUtils.CheckFsReturns(true, nil)
 			fakeBlockDeviceUtils.MakeFsReturns(nil)
 			fakeBlockDeviceUtils.MountFsReturns(callErr)
-			fakeBlockDeviceUtils.IsDirIsAMountPointReturns(false, nil, nil)
+			fakeBlockDeviceUtils.IsDirAMountPointReturns(false, nil, nil)
 
 			err = blockDeviceMounterUtils.MountDeviceFlow("fake_device", "fake_fstype", "fake_mountp")
 			Expect(err).To(HaveOccurred())
@@ -173,7 +173,7 @@ var _ = Describe("block_device_mounter_utils_test", func() {
 			fakeBlockDeviceUtils.CheckFsReturns(true, nil)
 			fakeBlockDeviceUtils.MakeFsReturns(nil)
 			fakeBlockDeviceUtils.MountFsReturns(nil)
-			fakeBlockDeviceUtils.IsDirIsAMountPointReturns(false, nil, nil)
+			fakeBlockDeviceUtils.IsDirAMountPointReturns(false, nil, nil)
 
 			err = blockDeviceMounterUtils.MountDeviceFlow("fake_device", "fake_fstype", "fake_mountp")
 			Expect(err).NotTo(HaveOccurred())

--- a/remote/mounter/block_device_mounter_utils/errors.go
+++ b/remote/mounter/block_device_mounter_utils/errors.go
@@ -34,6 +34,6 @@ type DirPathAlreadyMountedToWrongDevice struct {
 }
 
 func (e *DirPathAlreadyMountedToWrongDevice) Error() string {
-	return fmt.Sprintf("[%s] directory is already a mountpoint but to unexpected devices=%#v (expected mountpoint only on device=[%s])",
+	return fmt.Sprintf("[%s] directory is already a mountpoint but to unexpected devices=%v (expected mountpoint only on device=[%s])",
 		e.mountPoint, e.unexpectedDevicesRefs, e.expectedDevice)
 }


### PR DESCRIPTION
@danare found a wrong text in error message in #212.
The error DirPathAlreadyMountedToWrongDevice message was included the variable type. For example : "devices=[]string{"/dev/mapper/mpathv", "/dev/mapper/mpathv2"}".
So this PR fixs the text so it will be "devices=[/dev/mapper/mpathv /dev/mapper/mpathv2]"

In addition, I saw that I didn't align the a fake file with renamed interface isDirAMountPoint. So used this PR to fix that as well, so the UT should pass OK now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/214)
<!-- Reviewable:end -->
