### PR TITLE
Fix/Generic error for PV not found in DB (for plugin identification the PV existence)

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -26,3 +26,4 @@ testImport:
   version: c463cd2a8578290d4be7a25cba69de81cf35785e
 - package: github.com/jarcoal/httpmock
   version: 4442edb3db31196622da56482fd8d0fa375fba4d
+

--- a/local/scbe/datamodel.go
+++ b/local/scbe/datamodel.go
@@ -61,7 +61,7 @@ func (d *scbeDataModel) DeleteVolume(name string) error {
 		return err
 	}
 	if exists == false {
-		return d.logger.ErrorRet(&volumeNotFoundError{name}, "failed")
+		return d.logger.ErrorRet(&resources.VolumeNotFoundError{VolName: name}, "failed")
 	}
 
 	if err := d.database.Delete(&volume).Error; err != nil {
@@ -91,7 +91,8 @@ func (d *scbeDataModel) InsertVolume(volumeName string, wwn string, fstype strin
 	return nil
 }
 
-// GetVolume return ScbeVolume if exist in DB, else return false and err
+// GetVolume return ScbeVolume if exist in DB,
+// if vol not found then return false\nil, but if failed to find it due to error return false\error.
 func (d *scbeDataModel) GetVolume(name string) (ScbeVolume, bool, error) {
 	defer d.logger.Trace(logs.DEBUG)()
 

--- a/local/scbe/datamodel_wrapper.go
+++ b/local/scbe/datamodel_wrapper.go
@@ -81,9 +81,10 @@ func (d *scbeDataModelWrapper) GetVolume(name string, mustExist bool) (ScbeVolum
 	// verify existence
 	if mustExist != exists {
 		if exists {
-			err = &volAlreadyExistsError{name}
+			err = &resources.VolAlreadyExistsError{VolName: name}
 		} else {
-			err = &volumeNotFoundError{name}
+			err = &resources.VolumeNotFoundError{VolName: name}
+
 		}
 		return ScbeVolume{}, d.logger.ErrorRet(err, "failed", logs.Args{{"mustExist", mustExist}, {"exists", exists}})
 	}
@@ -99,7 +100,7 @@ func (d *scbeDataModelWrapper) DeleteVolume(name string) error {
 
 		// sanity
 		if d.dbVolume == nil {
-			return d.logger.ErrorRet(&volumeNotFoundError{name}, "failed")
+			return d.logger.ErrorRet(&resources.VolumeNotFoundError{VolName: name}, "failed")
 		}
 
 		// work with memory object
@@ -132,7 +133,7 @@ func (d *scbeDataModelWrapper) InsertVolume(volumeName string, wwn string, fstyp
 
 		// sanity
 		if d.dbVolume != nil {
-			return d.logger.ErrorRet(&volAlreadyExistsError{volumeName}, "failed")
+			return d.logger.ErrorRet(&resources.VolAlreadyExistsError{VolName: volumeName}, "failed")
 		}
 
 		// work with memory object

--- a/local/scbe/errors.go
+++ b/local/scbe/errors.go
@@ -40,14 +40,6 @@ func (e *mappingResponseError) Error() string {
 	return fmt.Sprintf("Mapping operation succeeded, but the mapping details are missing from the response. %#v", e.mapping)
 }
 
-type volumeNotFoundError struct {
-	volName string
-}
-
-func (e *volumeNotFoundError) Error() string {
-	return fmt.Sprintf("Volume [%s] was not found", e.volName)
-}
-
 type hostNotFoundvolumeNotFoundError struct {
 	volName   string
 	arrayName string
@@ -67,14 +59,6 @@ type activateDefaultServiceError struct {
 func (e *activateDefaultServiceError) Error() string {
 	return fmt.Sprintf("Spectrum Connect backend activation error. The default service [%s] does not exist on Spectrum Connect [%s]",
 		e.serviceName, e.scbeName)
-}
-
-type volAlreadyExistsError struct {
-	volName string
-}
-
-func (e *volAlreadyExistsError) Error() string {
-	return fmt.Sprintf("Volume [%s] already exists.", e.volName)
 }
 
 type provisionParamMissingError struct {
@@ -211,4 +195,14 @@ type InvalidMappingsForVolume struct {
 
 func (e *InvalidMappingsForVolume) Error() string {
 	return fmt.Sprintf("Invalid mappings for volume [%s]", e.volWwn)
+}
+
+const VolumeNotFoundOnArrayErrorMsg = "volume was not found on the Spectrum Connect interface."
+
+type VolumeNotFoundOnArrayError struct {
+	VolName string
+}
+
+func (e *VolumeNotFoundOnArrayError) Error() string {
+	return fmt.Sprintf("[%s] "+VolumeNotFoundOnArrayErrorMsg, e.VolName)
 }

--- a/local/scbe/scbe.go
+++ b/local/scbe/scbe.go
@@ -358,7 +358,7 @@ func (s *scbeLocalClient) GetVolumeConfig(getVolumeConfigRequest resources.GetVo
 
 	// verify volume is found
 	if len(volumeInfo) != 1 {
-		return nil, s.logger.ErrorRet(&volumeNotFoundError{getVolumeConfigRequest.Name}, "failed", logs.Args{{"volumeInfo", volumeInfo}})
+		return nil, s.logger.ErrorRet(&VolumeNotFoundOnArrayError{VolName: getVolumeConfigRequest.Name}, "failed", logs.Args{{"volumeInfo", volumeInfo}})
 	}
 
 	// serialize scbeVolumeInfo to json

--- a/local/scbe/scbe_rest_client.go
+++ b/local/scbe/scbe_rest_client.go
@@ -278,7 +278,7 @@ func (s *scbeRestClient) getHostIdByVol(wwn string, host string) (int, error) {
 	}
 
 	if len(vols) == 0 {
-		return 0, s.logger.ErrorRet(&volumeNotFoundError{wwn}, "failed")
+		return 0, s.logger.ErrorRet(&VolumeNotFoundOnArrayError{VolName: wwn}, "failed")
 	}
 	vol := vols[0]
 	payload := make(map[string]string)

--- a/local/scbe/scbe_test.go
+++ b/local/scbe/scbe_test.go
@@ -573,7 +573,11 @@ var _ = Describe("scbeLocalClient", func() {
 			fakeScbeRestClient.GetVolumesReturns(volumes, nil)
 			_, err := client.GetVolumeConfig(resources.GetVolumeConfigRequest{Name: "name"})
 			Expect(err).To(HaveOccurred())
+			_, ok := err.(*scbe.VolumeNotFoundOnArrayError)
+			Expect(ok).To(Equal(true))
+
 		})
+		// TODO add missing unit testing for GetVolumeConfig
 	})
 	Context(".Remove", func() {
 		It("should fail to remove the volume if GetVolume failed", func() {

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -16,7 +16,10 @@
 
 package resources
 
-import "github.com/jinzhu/gorm"
+import (
+	"fmt"
+	"github.com/jinzhu/gorm"
+)
 
 const (
 	SpectrumScale     string = "spectrum-scale"
@@ -150,6 +153,26 @@ type StorageClient interface {
 	GetVolumeConfig(getVolumeConfigRequest GetVolumeConfigRequest) (map[string]interface{}, error)
 	Attach(attachRequest AttachRequest) (string, error)
 	Detach(detachRequest DetachRequest) error
+}
+
+// volumeNotFoundError error for Attach, Detach, GetVolume, GetVolumeConfig, RemoveVolume interfaces if volume not found in Ubiquity DB
+const VolumeNotFoundErrorMsg = "volume was not found in Ubiqutiy database."
+
+type VolumeNotFoundError struct {
+	VolName string
+}
+
+func (e *VolumeNotFoundError) Error() string {
+	return fmt.Sprintf("[%s] "+VolumeNotFoundErrorMsg, e.VolName)
+}
+
+// volAlreadyExistsError error for Create interface if volume is already exist in the Ubiquity DB
+type VolAlreadyExistsError struct {
+	VolName string
+}
+
+func (e *VolAlreadyExistsError) Error() string {
+	return fmt.Sprintf("Volume [%s] already exists.", e.VolName)
 }
 
 //go:generate counterfeiter -o ../fakes/fake_mounter.go . Mounter


### PR DESCRIPTION
Refactor volumeNotFoundError in database to be standard error for StorageClient interface.

Move this error from scbe backend to be generic for ubiqutiy StorageClient interface,
So the plugins will be able to identify if the GetVolume interface fail to find the volume because an error or because it was not found in Ubiqutiy DB.
The first to use it in the plugin is the flex Unmount CLI to identify if PV exist in ubiquity before unmount start (for idempotent issue resolving)

This PR related to k8s plugin -> https://github.com/IBM/ubiquity-k8s/pull/193

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/216)
<!-- Reviewable:end -->
