### PR TITLE
UB-1097: added warning option to logs

### DIFF
--- a/utils/logs/go_logging_logger.go
+++ b/utils/logs/go_logging_logger.go
@@ -33,7 +33,7 @@ type goLoggingLogger struct {
 func newGoLoggingLogger(level Level, writer io.Writer) *goLoggingLogger {
 	newLogger := logging.MustGetLogger("")
 	newLogger.ExtraCalldepth = 1
-	format := logging.MustStringFormatter("%{time:2006-01-02 15:04:05.999} %{level:.5s} %{pid} %{shortfile} %{shortpkg}::%{shortfunc} %{message}")
+	format := logging.MustStringFormatter("%{time:2006-01-02 15:04:05.999} %{level:.7s} %{pid} %{shortfile} %{shortpkg}::%{shortfunc} %{message}")
 	backend := logging.NewLogBackend(writer, "", 0)
 	backendFormatter := logging.NewBackendFormatter(backend, format)
 	backendLeveled := logging.AddModuleLevel(backendFormatter)
@@ -57,6 +57,10 @@ func (l *goLoggingLogger) Error(str string, args ...Args) {
 func (l *goLoggingLogger) ErrorRet(err error, str string, args ...Args) error {
 	l.logger.Errorf(str+" %v ", append(args, Args{{"error", err}}))
 	return err
+}
+
+func (l *goLoggingLogger) Warning(str string, args ...Args) {
+	l.logger.Warning(str+" %v", args)
 }
 
 func (l *goLoggingLogger) Trace(level Level, args ...Args) func() {

--- a/utils/logs/logger.go
+++ b/utils/logs/logger.go
@@ -53,6 +53,8 @@ type Logger interface {
 	// It writes the ENTER message when called, and returns a function that writes the EXIT message,
 	// so it can be used with defer in 1 line
 	Trace(level Level, args ...Args) func()
+	// Warning writes the string and args at WARNING level
+	Warning(str string, args ...Args)
 }
 
 func (param nameValue) String() string {


### PR DESCRIPTION
In this PR I added the Warning option for the logger.
so now if we want to add logs in WARNING level we can just use logger.Warning()  (the same way it works for Info or Debug)