### PR TITLE
UB-1174: added tiemstamp to starting server log

### DIFF
--- a/web_server/storage_api_server.go
+++ b/web_server/storage_api_server.go
@@ -70,8 +70,8 @@ func (s *StorageApiServer) Start() error {
 }
 
 func (s *StorageApiServer) printStartMsg() {
-	fmt.Println(fmt.Sprintf("Starting Storage API server on port %d ....", s.config.Port))
-	fmt.Println("CTL-C to exit/stop Storage API server service")
+	s.logger.Info(fmt.Sprintf("Starting Storage API server on port %d ....", s.config.Port))
+	s.logger.Info("CTL-C to exit/stop Storage API server service")
 }
 
 func (s *StorageApiServer) StartNonSsl() error {


### PR DESCRIPTION
added timestamp to start server message: 
`2018-07-01 11:52:15.077 INFO storage_api_server.go:73 web_server::printStartMsg [NA:1] Starting Storage API server on port 9999 .... []
2018-07-01 11:52:15.077 INFO storage_api_server.go:74 web_server::printStartMsg [NA:1] CTL-C to exit/stop Storage API server service []
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/220)
<!-- Reviewable:end -->
