### PR TITLE
UB-1405: unmount flow should not fail if discovery fails

### DIFF
--- a/remote/mounter/block_device_utils/errors.go
+++ b/remote/mounter/block_device_utils/errors.go
@@ -36,12 +36,12 @@ func (e *commandExecuteError) Error() string {
 	return fmt.Sprintf("command [%v] execution failure [%v]", e.cmd, e.err)
 }
 
-type volumeNotFoundError struct {
-	volName string
+type VolumeNotFoundError struct {
+	VolName string
 }
 
-func (e *volumeNotFoundError) Error() string {
-	return fmt.Sprintf("volume [%v] is not found", e.volName)
+func (e *VolumeNotFoundError) Error() string {
+	return fmt.Sprintf("volume [%v] is not found", e.VolName)
 }
 
 type wrongDeviceFoundError struct {

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -77,13 +77,13 @@ func (b *blockDeviceUtils) Discover(volumeWwn string, deepDiscovery bool) (strin
 	if dev == "" {
 		if !deepDiscovery {
 			b.logger.Debug(fmt.Sprintf("mpath device was NOT found for WWN [%s] in multipath -ll. (sg_inq deep discovery not requested)", volumeWwn))
-			return "", b.logger.ErrorRet(&volumeNotFoundError{volumeWwn}, "failed")
+			return "", b.logger.ErrorRet(&VolumeNotFoundError{volumeWwn}, "failed")
 		}
 		b.logger.Debug(fmt.Sprintf("mpath device for WWN [%s] was NOT found in multipath -ll. Doing advance search with sg_inq on all mpath devices in multipath -ll", volumeWwn))
 		dev, err = b.DiscoverBySgInq(string(outputBytes[:]), volumeWwn)
 		if err != nil {
 			b.logger.Debug(fmt.Sprintf("mpath device was NOT found for WWN [%s] even after sg_inq on all mpath devices.", volumeWwn))
-			return "", b.logger.ErrorRet(&volumeNotFoundError{volumeWwn}, "failed")
+			return "", b.logger.ErrorRet(&VolumeNotFoundError{volumeWwn}, "failed")
 		} else {
 			b.logger.Warning(fmt.Sprintf("device [%s] found for WWN [%s] after running sg_inq on all mpath devices although it was not found in multipath -ll. (Note: Could indicate multipathing issue).", dev, volumeWwn))
 			mpath = b.mpathDevFullPath(dev)
@@ -132,14 +132,14 @@ func (b *blockDeviceUtils) DiscoverBySgInq(mpathOutput string, volumeWwn string)
 			mpathFullPath := b.mpathDevFullPath(dev)
 			wwn, err := b.GetWwnByScsiInq(mpathFullPath)
 			if err != nil {
-				return "", b.logger.ErrorRet(&volumeNotFoundError{volumeWwn}, "failed")
+				return "", b.logger.ErrorRet(&VolumeNotFoundError{volumeWwn}, "failed")
 			}
 			if strings.ToLower(wwn) == strings.ToLower(volumeWwn) {
 				return dev, nil
 			}
 		}
 	}
-	return "", b.logger.ErrorRet(&volumeNotFoundError{volumeWwn}, "failed")
+	return "", b.logger.ErrorRet(&VolumeNotFoundError{volumeWwn}, "failed")
 }
 
 func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
@@ -225,7 +225,7 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 		}
 
 	}
-	return "", b.logger.ErrorRet(&volumeNotFoundError{wwn}, "failed")
+	return "", b.logger.ErrorRet(&VolumeNotFoundError{wwn}, "failed")
 }
 
 func (b *blockDeviceUtils) Cleanup(mpath string) error {

--- a/remote/mounter/mounter_factory.go
+++ b/remote/mounter/mounter_factory.go
@@ -3,6 +3,8 @@ package mounter
 import (
 	"github.com/IBM/ubiquity/resources"
 	"github.com/IBM/ubiquity/utils/logs"
+	"github.com/IBM/ubiquity/utils"
+	"github.com/IBM/ubiquity/remote/mounter/block_device_mounter_utils"
 	"log"
 )
 
@@ -30,7 +32,9 @@ func (m *mounterFactory) GetMounterPerBackend(backend string, legacyLogger *log.
 	} else if backend == resources.SoftlayerNFS || backend == resources.SpectrumScaleNFS {
 		return NewNfsMounter(legacyLogger), nil
 	} else if backend == resources.SCBE {
-		return NewScbeMounter(pluginConfig.ScbeRemoteConfig), nil
+		blockDeviceMounterUtils := block_device_mounter_utils.NewBlockDeviceMounterUtils()
+		executer := utils.NewExecutor()
+		return NewScbeMounter(pluginConfig.ScbeRemoteConfig, blockDeviceMounterUtils, executer), nil
 	} else {
 		return nil, &NoMounterForVolumeError{backend}
 	}

--- a/remote/mounter/mounter_factory.go
+++ b/remote/mounter/mounter_factory.go
@@ -3,8 +3,6 @@ package mounter
 import (
 	"github.com/IBM/ubiquity/resources"
 	"github.com/IBM/ubiquity/utils/logs"
-	"github.com/IBM/ubiquity/utils"
-	"github.com/IBM/ubiquity/remote/mounter/block_device_mounter_utils"
 	"log"
 )
 
@@ -32,9 +30,7 @@ func (m *mounterFactory) GetMounterPerBackend(backend string, legacyLogger *log.
 	} else if backend == resources.SoftlayerNFS || backend == resources.SpectrumScaleNFS {
 		return NewNfsMounter(legacyLogger), nil
 	} else if backend == resources.SCBE {
-		blockDeviceMounterUtils := block_device_mounter_utils.NewBlockDeviceMounterUtils()
-		executer := utils.NewExecutor()
-		return NewScbeMounter(pluginConfig.ScbeRemoteConfig, blockDeviceMounterUtils, executer), nil
+		return NewScbeMounter(pluginConfig.ScbeRemoteConfig), nil
 	} else {
 		return nil, &NoMounterForVolumeError{backend}
 	}

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -32,7 +32,17 @@ type scbeMounter struct {
 	config                  resources.ScbeRemoteConfig
 }
 
-func NewScbeMounter(scbeRemoteConfig resources.ScbeRemoteConfig, blockDeviceMounterUtils block_device_mounter_utils.BlockDeviceMounterUtils, executer utils.Executor) resources.Mounter {
+func NewScbeMounter(scbeRemoteConfig resources.ScbeRemoteConfig) resources.Mounter {
+	blockDeviceMounterUtils := block_device_mounter_utils.NewBlockDeviceMounterUtils()
+	return &scbeMounter{
+		logger:                  logs.GetLogger(),
+		blockDeviceMounterUtils: blockDeviceMounterUtils,
+		exec:   utils.NewExecutor(),
+		config: scbeRemoteConfig,
+	}
+}
+
+func NewScbeMounterWithExecuter(scbeRemoteConfig resources.ScbeRemoteConfig, blockDeviceMounterUtils block_device_mounter_utils.BlockDeviceMounterUtils, executer utils.Executor) resources.Mounter {
 	return &scbeMounter{
 		logger:                  logs.GetLogger(),
 		blockDeviceMounterUtils: blockDeviceMounterUtils,
@@ -40,6 +50,7 @@ func NewScbeMounter(scbeRemoteConfig resources.ScbeRemoteConfig, blockDeviceMoun
 		config: scbeRemoteConfig,
 	}
 }
+
 
 func (s *scbeMounter) Mount(mountRequest resources.MountRequest) (string, error) {
 	defer s.logger.Trace(logs.DEBUG)()

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -102,11 +102,11 @@ func (s *scbeMounter) Unmount(unmountRequest resources.UnmountRequest) error {
 	devicePath, err := s.blockDeviceMounterUtils.Discover(volumeWWN, true)
 	if err != nil {
 		switch err.(type) {
-        case *block_device_utils.VolumeNotFoundError:
-            s.logger.Warning("Idempotent issue encountered: volume not found. skipping UnmountDeviceFlow ",logs.Args{{"volumeWWN", volumeWWN}} )
-			skipUnmountFlow = true	
-        default:
-            return s.logger.ErrorRet(err, "Discover failed", logs.Args{{"volumeWWN", volumeWWN}})
+	        case *block_device_utils.VolumeNotFoundError:
+	            s.logger.Warning("Idempotent issue encountered: volume not found. skipping UnmountDeviceFlow ",logs.Args{{"volumeWWN", volumeWWN}} )
+				skipUnmountFlow = true	
+	        default:
+	            return s.logger.ErrorRet(err, "Discover failed", logs.Args{{"volumeWWN", volumeWWN}})
         }
 	}
 	if !skipUnmountFlow{

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -19,6 +19,7 @@ package mounter
 import (
 	"fmt"
 	"github.com/IBM/ubiquity/remote/mounter/block_device_mounter_utils"
+	"github.com/IBM/ubiquity/remote/mounter/block_device_utils"
 	"github.com/IBM/ubiquity/resources"
 	"github.com/IBM/ubiquity/utils"
 	"github.com/IBM/ubiquity/utils/logs"
@@ -31,12 +32,11 @@ type scbeMounter struct {
 	config                  resources.ScbeRemoteConfig
 }
 
-func NewScbeMounter(scbeRemoteConfig resources.ScbeRemoteConfig) resources.Mounter {
-	blockDeviceMounterUtils := block_device_mounter_utils.NewBlockDeviceMounterUtils()
+func NewScbeMounter(scbeRemoteConfig resources.ScbeRemoteConfig, blockDeviceMounterUtils block_device_mounter_utils.BlockDeviceMounterUtils, executer utils.Executor) resources.Mounter {
 	return &scbeMounter{
 		logger:                  logs.GetLogger(),
 		blockDeviceMounterUtils: blockDeviceMounterUtils,
-		exec:   utils.NewExecutor(),
+		exec:  executer,
 		config: scbeRemoteConfig,
 	}
 }
@@ -88,16 +88,23 @@ func (s *scbeMounter) Unmount(unmountRequest resources.UnmountRequest) error {
 
 	volumeWWN := unmountRequest.VolumeConfig["Wwn"].(string)
 	mountpoint := fmt.Sprintf(resources.PathToMountUbiquityBlockDevices, volumeWWN) // TODO instead of build the mountpoint it should come from unmountRequest.
+	skipUnmountFlow := false
 	devicePath, err := s.blockDeviceMounterUtils.Discover(volumeWWN, true)
 	if err != nil {
-		// TODO idempotent, if volumeNotFoundError then skip UnmountDeviceFlow
-		return s.logger.ErrorRet(err, "Discover failed", logs.Args{{"volumeWWN", volumeWWN}})
+		expectedError := &block_device_utils.VolumeNotFoundError{volumeWWN}
+		if err.Error() == expectedError.Error(){
+			s.logger.Warning("Idempotent issue encountered: volume not found. skipping UnmountDeviceFlow ",logs.Args{{"volumeWWN", volumeWWN}} )
+			skipUnmountFlow = true	
+		} else {
+			return s.logger.ErrorRet(err, "Discover failed", logs.Args{{"volumeWWN", volumeWWN}})
+		}
 	}
-
-	if err := s.blockDeviceMounterUtils.UnmountDeviceFlow(devicePath); err != nil {
-		return s.logger.ErrorRet(err, "UnmountDeviceFlow failed", logs.Args{{"devicePath", devicePath}})
+	if !skipUnmountFlow{
+		if err := s.blockDeviceMounterUtils.UnmountDeviceFlow(devicePath); err != nil {
+			return s.logger.ErrorRet(err, "UnmountDeviceFlow failed", logs.Args{{"devicePath", devicePath}})
+		}
 	}
-
+	
 	s.logger.Info("Delete mountpoint directory if exist", logs.Args{{"mountpoint", mountpoint}})
 	// TODO move this part to the util
 	if _, err := s.exec.Stat(mountpoint); err == nil {

--- a/remote/mounter/scbe_test.go
+++ b/remote/mounter/scbe_test.go
@@ -1,0 +1,97 @@
+package mounter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/IBM/ubiquity/fakes"
+	"github.com/IBM/ubiquity/remote/mounter"
+	"github.com/IBM/ubiquity/remote/mounter/block_device_utils"
+	"github.com/IBM/ubiquity/resources"
+	"github.com/IBM/ubiquity/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("scbe_mounter_test", func() {
+	var (
+		fakeExec    *fakes.FakeExecutor
+		fakeBdUtils *fakes.FakeBlockDeviceMounterUtils
+		scbeMounter resources.Mounter
+	)
+
+	BeforeEach(func() {
+		fakeExec = new(fakes.FakeExecutor)
+		fakeBdUtils = new(fakes.FakeBlockDeviceMounterUtils)
+		scbeMounter = mounter.NewScbeMounter(resources.ScbeRemoteConfig{}, fakeBdUtils, fakeExec)
+	})
+
+	Context(".Unmount", func() {
+		It("should continue flow if volume is not discovered", func() {
+			returnedErr := &block_device_utils.VolumeNotFoundError{"volumewwn"}
+			fakeBdUtils.DiscoverReturns("", returnedErr)
+			volumeConfig := make(map[string]interface{})
+			volumeConfig["Wwn"] = "volumewwn"
+			err := scbeMounter.Unmount(resources.UnmountRequest{volumeConfig, resources.RequestContext{}})
+			Expect(err).To(BeNil())
+			Expect(fakeBdUtils.UnmountDeviceFlowCallCount()).To(Equal(0))
+			Expect(fakeExec.StatCallCount()).To(Equal(1))
+		})
+		It("should fail if error from discovery is not voumeNotFound", func() {
+			returnedErr := fmt.Errorf("An error has occured")
+			fakeBdUtils.DiscoverReturns("", returnedErr)
+			volumeConfig := make(map[string]interface{})
+			volumeConfig["Wwn"] = "volumewwn"
+			err := scbeMounter.Unmount(resources.UnmountRequest{volumeConfig, resources.RequestContext{}})
+			Expect(err).To(Equal(returnedErr))
+			Expect(fakeBdUtils.UnmountDeviceFlowCallCount()).To(Equal(0))
+			Expect(fakeExec.StatCallCount()).To(Equal(0))
+		})
+		It("should call unmountDeviceFlow if discover succeeded", func() {
+			volumeConfig := make(map[string]interface{})
+			volumeConfig["Wwn"] = "volumewwn"
+			err := scbeMounter.Unmount(resources.UnmountRequest{volumeConfig, resources.RequestContext{}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeBdUtils.UnmountDeviceFlowCallCount()).To(Equal(1))
+			Expect(fakeExec.StatCallCount()).To(Equal(1))
+		})
+		It("should fail if unmountDeviceFlow returns an error", func() {
+			returnedErr := fmt.Errorf("An error has occured")
+			fakeBdUtils.UnmountDeviceFlowReturns(returnedErr)
+			volumeConfig := make(map[string]interface{})
+			volumeConfig["Wwn"] = "volumewwn"
+			err := scbeMounter.Unmount(resources.UnmountRequest{volumeConfig, resources.RequestContext{}})
+			Expect(err).To(HaveOccurred())
+			Expect(fakeBdUtils.UnmountDeviceFlowCallCount()).To(Equal(1))
+			Expect(fakeExec.StatCallCount()).To(Equal(0))
+		})
+		It("should not fail if stat on file returns error", func() {
+			returnedErr := fmt.Errorf("An error has occured")
+			fakeExec.StatReturns(nil, returnedErr)
+			volumeConfig := make(map[string]interface{})
+			volumeConfig["Wwn"] = "volumewwn"
+			err := scbeMounter.Unmount(resources.UnmountRequest{volumeConfig, resources.RequestContext{}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeBdUtils.UnmountDeviceFlowCallCount()).To(Equal(1))
+			Expect(fakeExec.StatCallCount()).To(Equal(1))
+			Expect(fakeExec.RemoveAllCallCount()).To(Equal(0))
+		})
+		It("should  fail if Removeall returns error", func() {
+			returnedErr := fmt.Errorf("An error has occured")
+			fakeExec.RemoveAllReturns(returnedErr)
+			volumeConfig := make(map[string]interface{})
+			volumeConfig["Wwn"] = "volumewwn"
+			err := scbeMounter.Unmount(resources.UnmountRequest{volumeConfig, resources.RequestContext{}})
+			Expect(err).To(HaveOccurred())
+			Expect(fakeBdUtils.UnmountDeviceFlowCallCount()).To(Equal(1))
+			Expect(fakeExec.StatCallCount()).To(Equal(1))
+			Expect(fakeExec.RemoveAllCallCount()).To(Equal(1))
+		})
+	})
+})
+
+func TestSCBEMounter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	defer utils.InitUbiquityServerTestLogger()()
+	RunSpecs(t, "SCBEMounter Test Suite")
+}

--- a/remote/mounter/scbe_test.go
+++ b/remote/mounter/scbe_test.go
@@ -23,7 +23,7 @@ var _ = Describe("scbe_mounter_test", func() {
 	BeforeEach(func() {
 		fakeExec = new(fakes.FakeExecutor)
 		fakeBdUtils = new(fakes.FakeBlockDeviceMounterUtils)
-		scbeMounter = mounter.NewScbeMounter(resources.ScbeRemoteConfig{}, fakeBdUtils, fakeExec)
+		scbeMounter = mounter.NewScbeMounterWithExecuter(resources.ScbeRemoteConfig{}, fakeBdUtils, fakeExec)
 	})
 
 	Context(".Unmount", func() {


### PR DESCRIPTION
In this PR , the following idempotent issue with Unmount flow is fixed:
if a discovery of a volume fails, no need to fail the Unmount command, just need to skip the UnmountDeviceFlow.

more info:
if volume's mpath NOT discovered (because the device does not exist at all in multipath -ll) then we should skip UnmountDeviceFlow instead of failing (reminder - the UnmountDeviceFlow is the flow that does umount the device and cleanup of the mpath device) .    
Why its idempotent? - because there is a chance that unmount flow will fail  at the end of UnmountDeviceFlow after it unmounts and cleans the mpath device. So to be idempotent the unmount needs to handle unmount request while the mpath device was already cleaned.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/229)
<!-- Reviewable:end -->
