### PR TITLE
expose the http error reason also to the plugins (provisioner\flex)

### DIFF
--- a/local/scbe/errors.go
+++ b/local/scbe/errors.go
@@ -28,8 +28,8 @@ type serviceDoesntExistError struct {
 }
 
 func (e *serviceDoesntExistError) Error() string {
-	return fmt.Sprintf("Cannot create volume [%s] on Spectrum Connect service [%s]. The service does not exist or it is not delegated to the %s interface in [%s]",
-		e.volName, e.serviceName, resources.ScbeInterfaceName, e.scbeName)
+	return fmt.Sprintf("Cannot create volume [%s] on %s service [%s]. The service does not exist or it is not delegated to the %s interface in [%s]",
+		e.volName, ScName, e.serviceName, resources.ScbeInterfaceName, e.scbeName)
 }
 
 type mappingResponseError struct {
@@ -47,8 +47,8 @@ type hostNotFoundvolumeNotFoundError struct {
 }
 
 func (e *hostNotFoundvolumeNotFoundError) Error() string {
-	return fmt.Sprintf("Host name [%s], related to the volume with WWN [%s] was not found on the storage system [%s], according to Spectrum Connect caching data",
-		e.hostName, e.volName, e.arrayName)
+	return fmt.Sprintf("Host name [%s], related to the volume with WWN [%s] was not found on the storage system [%s], according to %s caching data",
+		e.hostName, e.volName, e.arrayName, ScName)
 }
 
 type activateDefaultServiceError struct {
@@ -57,8 +57,8 @@ type activateDefaultServiceError struct {
 }
 
 func (e *activateDefaultServiceError) Error() string {
-	return fmt.Sprintf("Spectrum Connect backend activation error. The default service [%s] does not exist on Spectrum Connect [%s]",
-		e.serviceName, e.scbeName)
+	return fmt.Sprintf("%s backend activation error. The default service [%s] does not exist on %s [%s]",
+		ScName, e.serviceName, ScName, e.scbeName)
 }
 
 type provisionParamMissingError struct {
@@ -197,7 +197,7 @@ func (e *InvalidMappingsForVolume) Error() string {
 	return fmt.Sprintf("Invalid mappings for volume [%s]", e.volWwn)
 }
 
-const VolumeNotFoundOnArrayErrorMsg = "volume was not found on the Spectrum Connect interface."
+const VolumeNotFoundOnArrayErrorMsg = "volume was not found on the " + ScName + " interface."
 
 type VolumeNotFoundOnArrayError struct {
 	VolName string
@@ -206,8 +206,6 @@ type VolumeNotFoundOnArrayError struct {
 func (e *VolumeNotFoundOnArrayError) Error() string {
 	return fmt.Sprintf("[%s] "+VolumeNotFoundOnArrayErrorMsg, e.VolName)
 }
-
-const BadHttpStatusCodeErrorMsg = ScName + " - bad http status code"
 
 type BadHttpStatusCodeError struct {
 	httpStatus string
@@ -219,7 +217,7 @@ type BadHttpStatusCodeError struct {
 func (e *BadHttpStatusCodeError) Error() string {
 	return fmt.Sprintf("%s [%s]. response data [%s]. request action [%s] and url [%s].",
 		ScName,
-		VolumeNotFoundOnArrayErrorMsg,
+		"bad http status code",
 		e.httpStatus,
 		e.httpData,
 		e.httpAction,

--- a/local/scbe/errors.go
+++ b/local/scbe/errors.go
@@ -208,18 +208,19 @@ func (e *VolumeNotFoundOnArrayError) Error() string {
 }
 
 type BadHttpStatusCodeError struct {
-	httpStatus string
-	httpData   string
-	httpAction string
-	httpUrl    string
+	httpStatusCode         int
+	httpExpectedStatusCode int
+	httpDataStr            string
+	httpAction             string
+	httpUrl                string
 }
 
 func (e *BadHttpStatusCodeError) Error() string {
-	return fmt.Sprintf("%s [%s]. response data [%s]. request action [%s] and url [%s].",
-		ScName,
-		"bad http status code",
-		e.httpStatus,
-		e.httpData,
+	return fmt.Sprintf(
+		ScName+" unexpected HTTP status code. HTTP response detail: 'status code'=[%d], 'expected status code'=[%d], 'data'=[%s], 'action'=[%s], 'url'=[%s].",
+		e.httpStatusCode,
+		e.httpExpectedStatusCode,
+		e.httpDataStr,
 		e.httpAction,
 		e.httpUrl,
 	)

--- a/local/scbe/errors.go
+++ b/local/scbe/errors.go
@@ -206,3 +206,23 @@ type VolumeNotFoundOnArrayError struct {
 func (e *VolumeNotFoundOnArrayError) Error() string {
 	return fmt.Sprintf("[%s] "+VolumeNotFoundOnArrayErrorMsg, e.VolName)
 }
+
+const BadHttpStatusCodeErrorMsg = ScName + " - bad http status code"
+
+type BadHttpStatusCodeError struct {
+	httpStatus string
+	httpData   string
+	httpAction string
+	httpUrl    string
+}
+
+func (e *BadHttpStatusCodeError) Error() string {
+	return fmt.Sprintf("%s [%s]. response data [%s]. request action [%s] and url [%s].",
+		ScName,
+		VolumeNotFoundOnArrayErrorMsg,
+		e.httpStatus,
+		e.httpData,
+		e.httpAction,
+		e.httpUrl,
+	)
+}

--- a/local/scbe/resources.go
+++ b/local/scbe/resources.go
@@ -22,6 +22,10 @@ type LoginResponse struct {
 	Token string `json:"token"`
 }
 
+const (
+	ScName = "Spectrum Connect"
+)
+
 type ScbeStorageService struct {
 	Id                                 string `json:"id"`
 	UniqueIdentifier                   string `json:"unique_identifier"`

--- a/local/scbe/simple_rest_client.go
+++ b/local/scbe/simple_rest_client.go
@@ -169,8 +169,13 @@ func (s *simpleRestClient) genericActionInternal(actionName string, resource_url
 	httpDataStr := string(data[:])
 	s.logger.Debug(actionName+" "+url, logs.Args{{"data", httpDataStr}})
 	if response.StatusCode != exitStatus {
-		return s.logger.ErrorRet(&BadHttpStatusCodeError{response.Status, httpDataStr, actionName, url},
-			"failed")
+		return s.logger.ErrorRet(&BadHttpStatusCodeError{
+			httpStatusCode:         response.StatusCode,
+			httpExpectedStatusCode: exitStatus,
+			httpDataStr:            httpDataStr,
+			httpAction:             actionName,
+			httpUrl:                url,
+		}, "failed")
 	}
 
 	if v != nil {

--- a/local/scbe/simple_rest_client.go
+++ b/local/scbe/simple_rest_client.go
@@ -166,9 +166,11 @@ func (s *simpleRestClient) genericActionInternal(actionName string, resource_url
 		return s.logger.ErrorRet(err, "ioutil.ReadAll failed")
 	}
 
-	s.logger.Debug(actionName+" "+url, logs.Args{{"data", string(data[:])}})
+	httpDataStr := string(data[:])
+	s.logger.Debug(actionName+" "+url, logs.Args{{"data", httpDataStr}})
 	if response.StatusCode != exitStatus {
-		return s.logger.ErrorRet(errors.New("bad status code "+response.Status), "failed", logs.Args{{actionName, url}})
+		return s.logger.ErrorRet(&BadHttpStatusCodeError{response.Status, httpDataStr, actionName, url},
+			"failed")
 	}
 
 	if v != nil {

--- a/local/scbe/simple_rest_client_test.go
+++ b/local/scbe/simple_rest_client_test.go
@@ -99,7 +99,8 @@ var _ = Describe("restClient", func() {
 			httpmock.RegisterResponder("POST", fakeScbeUrlAuthFull, httpmock.NewStringResponder(http.StatusBadRequest, "{}"))
 			err = client.Login()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(MatchRegexp("^bad status code"))
+			_, ok := err.(*scbe.BadHttpStatusCodeError)
+			Expect(ok).To(Equal(true))
 		})
 		It("should fail when httpClient.Post returns invalid json", func() {
 			httpmock.RegisterResponder("POST", fakeScbeUrlAuthFull, httpmock.NewStringResponder(http.StatusOK, "yyy"))
@@ -153,7 +154,8 @@ var _ = Describe("restClient", func() {
 			var services []scbe.ScbeStorageService
 			err = client.Get(scbe.UrlScbeResourceService, nil, -1, &services)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(MatchRegexp("^bad status code"))
+			_, ok := err.(*scbe.BadHttpStatusCodeError)
+			Expect(ok).To(Equal(true))
 		})
 		It("should fail when httpClient.Get returns invalid json", func() {
 			httpmock.RegisterResponder(


### PR DESCRIPTION
This PR improve the ability to troubleshooting Spectrum Connect http issues, so the errors information will be also visible from the provisioner and flex log (and not only in the ubiqutiy server log).

Currently When ubiqutiy gets http error from Spectrum Connect it raises an error and the plugin(e.g provisioner) will show this error in the log. BUT the problem is that ubiqutiy raised only the http error code and NOT the http data, which may includes the reason of the http error.

So this PR fix it and add new error type that also include the http response data, so the plugins will also show it in there logs.

Internal issue -> UB-115

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/230)
<!-- Reviewable:end -->
