### PR TITLE
UB-1408: fix idempotent issue#6 - dont raise error on detach in ubiquity server

### DIFF
--- a/local/scbe/scbe.go
+++ b/local/scbe/scbe.go
@@ -457,10 +457,9 @@ func (s *scbeLocalClient) Detach(detachRequest resources.DetachRequest) (err err
 		return s.logger.ErrorRet(err, "scbeRestClient.GetVolMapping failed")
 	}
 
-	// Fail if vol already detach
 	if hostAttach == EmptyHost {
-		// TODO idempotent, if not attach then return nil
-		return s.logger.ErrorRet(&volNotAttachedError{detachRequest.Name}, "failed")
+		s.logger.Warning("Volume is already detached from host.", logs.Args{{"volume", existingVolume.WWN}})
+		return nil
 	}
 
 	// TODO idempotent, if volume attach to different host, then we should also return succeed.

--- a/local/scbe/scbe_test.go
+++ b/local/scbe/scbe_test.go
@@ -498,7 +498,7 @@ var _ = Describe("scbeLocalClient", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(fakeErr))
 		})
-		It("should fail to detach the volume if vol not exist in DB", func() {
+		It("should not fail to detach the volume if vol not exist in DB", func() {
 			fakeScbeDataModel.GetVolumeReturns(scbe.ScbeVolume{}, nil)
 			err := client.Detach(fakeDetachRequest)
 			Expect(err).ToNot(HaveOccurred())

--- a/local/scbe/scbe_test.go
+++ b/local/scbe/scbe_test.go
@@ -501,12 +501,9 @@ var _ = Describe("scbeLocalClient", func() {
 		It("should fail to detach the volume if vol not exist in DB", func() {
 			fakeScbeDataModel.GetVolumeReturns(scbe.ScbeVolume{}, nil)
 			err := client.Detach(fakeDetachRequest)
-			Expect(err).To(HaveOccurred())
-		})
-		It("should fail to detach the volume if vol already detached in DB", func() {
-			fakeScbeDataModel.GetVolumeReturns(scbe.ScbeVolume{}, nil)
-			err := client.Detach(fakeDetachRequest)
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeScbeRestClient.GetVolMappingCallCount()).To(Equal(1))
+			Expect(fakeScbeRestClient.UnmapVolumeCallCount()).To(Equal(0))
 		})
 		It("should fail to detach the volume if MapVolume failed", func() {
 			fakeScbeDataModel.GetVolumeReturns(scbe.ScbeVolume{}, nil)


### PR DESCRIPTION
In the ubiquity server if the volume is already detached we will not fail the flow but succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/231)
<!-- Reviewable:end -->
