### PR TITLE
UB-1472: add idempotent message

### DIFF
--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -23,6 +23,7 @@ import (
 	"github.com/IBM/ubiquity/resources"
 	"github.com/IBM/ubiquity/utils"
 	"github.com/IBM/ubiquity/utils/logs"
+	"os"
 )
 
 type scbeMounter struct {
@@ -120,6 +121,10 @@ func (s *scbeMounter) Unmount(unmountRequest resources.UnmountRequest) error {
 	if _, err := s.exec.Stat(mountpoint); err == nil {
 		if err := s.exec.RemoveAll(mountpoint); err != nil { // TODO its enough to do Remove without All.
 			return s.logger.ErrorRet(err, "RemoveAll failed", logs.Args{{"mountpoint", mountpoint}})
+		}
+	} else{
+		if os.IsNotExist(err){
+			s.logger.Warning("Idempotent issue encountered: mountpoint directory does not exist.", logs.Args{{"mountpoint", mountpoint}})
 		}
 	}
 


### PR DESCRIPTION
added a message to the log to indicate an idempotent case has occurred: 
we skipped the deletion of the mountpoint when it already does not exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/232)
<!-- Reviewable:end -->
