### PR TITLE
UB-1474: added logging message to indicate an idempotent issue

### DIFF
--- a/fakes/fake_block_device_mounter_utils.go
+++ b/fakes/fake_block_device_mounter_utils.go
@@ -48,10 +48,11 @@ type FakeBlockDeviceMounterUtils struct {
 		result1 string
 		result2 error
 	}
-	UnmountDeviceFlowStub        func(devicePath string) error
+	UnmountDeviceFlowStub        func(devicePath string, volumeWwn string) error
 	unmountDeviceFlowMutex       sync.RWMutex
 	unmountDeviceFlowArgsForCall []struct {
 		devicePath string
+		volumeWwn  string
 	}
 	unmountDeviceFlowReturns struct {
 		result1 error
@@ -215,16 +216,17 @@ func (fake *FakeBlockDeviceMounterUtils) DiscoverReturnsOnCall(i int, result1 st
 	}{result1, result2}
 }
 
-func (fake *FakeBlockDeviceMounterUtils) UnmountDeviceFlow(devicePath string) error {
+func (fake *FakeBlockDeviceMounterUtils) UnmountDeviceFlow(devicePath string, volumeWwn string) error {
 	fake.unmountDeviceFlowMutex.Lock()
 	ret, specificReturn := fake.unmountDeviceFlowReturnsOnCall[len(fake.unmountDeviceFlowArgsForCall)]
 	fake.unmountDeviceFlowArgsForCall = append(fake.unmountDeviceFlowArgsForCall, struct {
 		devicePath string
-	}{devicePath})
-	fake.recordInvocation("UnmountDeviceFlow", []interface{}{devicePath})
+		volumeWwn  string
+	}{devicePath, volumeWwn})
+	fake.recordInvocation("UnmountDeviceFlow", []interface{}{devicePath, volumeWwn})
 	fake.unmountDeviceFlowMutex.Unlock()
 	if fake.UnmountDeviceFlowStub != nil {
-		return fake.UnmountDeviceFlowStub(devicePath)
+		return fake.UnmountDeviceFlowStub(devicePath, volumeWwn)
 	}
 	if specificReturn {
 		return ret.result1
@@ -238,10 +240,10 @@ func (fake *FakeBlockDeviceMounterUtils) UnmountDeviceFlowCallCount() int {
 	return len(fake.unmountDeviceFlowArgsForCall)
 }
 
-func (fake *FakeBlockDeviceMounterUtils) UnmountDeviceFlowArgsForCall(i int) string {
+func (fake *FakeBlockDeviceMounterUtils) UnmountDeviceFlowArgsForCall(i int) (string, string) {
 	fake.unmountDeviceFlowMutex.RLock()
 	defer fake.unmountDeviceFlowMutex.RUnlock()
-	return fake.unmountDeviceFlowArgsForCall[i].devicePath
+	return fake.unmountDeviceFlowArgsForCall[i].devicePath, fake.unmountDeviceFlowArgsForCall[i].volumeWwn
 }
 
 func (fake *FakeBlockDeviceMounterUtils) UnmountDeviceFlowReturns(result1 error) {

--- a/fakes/fake_block_device_utils.go
+++ b/fakes/fake_block_device_utils.go
@@ -117,10 +117,11 @@ type FakeBlockDeviceUtils struct {
 	mountFsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UmountFsStub        func(mpoint string) error
+	UmountFsStub        func(mpoint string, volumeWwn string) error
 	umountFsMutex       sync.RWMutex
 	umountFsArgsForCall []struct {
-		mpoint string
+		mpoint    string
+		volumeWwn string
 	}
 	umountFsReturns struct {
 		result1 error
@@ -602,16 +603,17 @@ func (fake *FakeBlockDeviceUtils) MountFsReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeBlockDeviceUtils) UmountFs(mpoint string) error {
+func (fake *FakeBlockDeviceUtils) UmountFs(mpoint string, volumeWwn string) error {
 	fake.umountFsMutex.Lock()
 	ret, specificReturn := fake.umountFsReturnsOnCall[len(fake.umountFsArgsForCall)]
 	fake.umountFsArgsForCall = append(fake.umountFsArgsForCall, struct {
-		mpoint string
-	}{mpoint})
-	fake.recordInvocation("UmountFs", []interface{}{mpoint})
+		mpoint    string
+		volumeWwn string
+	}{mpoint, volumeWwn})
+	fake.recordInvocation("UmountFs", []interface{}{mpoint, volumeWwn})
 	fake.umountFsMutex.Unlock()
 	if fake.UmountFsStub != nil {
-		return fake.UmountFsStub(mpoint)
+		return fake.UmountFsStub(mpoint, volumeWwn)
 	}
 	if specificReturn {
 		return ret.result1
@@ -625,10 +627,10 @@ func (fake *FakeBlockDeviceUtils) UmountFsCallCount() int {
 	return len(fake.umountFsArgsForCall)
 }
 
-func (fake *FakeBlockDeviceUtils) UmountFsArgsForCall(i int) string {
+func (fake *FakeBlockDeviceUtils) UmountFsArgsForCall(i int) (string, string) {
 	fake.umountFsMutex.RLock()
 	defer fake.umountFsMutex.RUnlock()
-	return fake.umountFsArgsForCall[i].mpoint
+	return fake.umountFsArgsForCall[i].mpoint, fake.umountFsArgsForCall[i].volumeWwn
 }
 
 func (fake *FakeBlockDeviceUtils) UmountFsReturns(result1 error) {

--- a/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
+++ b/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
@@ -112,6 +112,7 @@ func (b *blockDeviceMounterUtils) MountDeviceFlow(devicePath string, fsType stri
 
 // UnmountDeviceFlow umount device, clean device and remove mountpoint folder
 func (b *blockDeviceMounterUtils) UnmountDeviceFlow(devicePath string, volumeWwn string) error {
+	// volumeWWN param is only used for logging - for the XAVI automation idempotent tests
 	// TODO consider also to receive the mountpoint(not only the devicepath), so the umount will use the mountpoint instead of the devicepath for future support double mounting of the same device.
 	defer b.logger.Trace(logs.INFO, logs.Args{{"devicePath", devicePath}})
 

--- a/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
+++ b/remote/mounter/block_device_mounter_utils/block_device_mounter_utils.go
@@ -111,11 +111,11 @@ func (b *blockDeviceMounterUtils) MountDeviceFlow(devicePath string, fsType stri
 }
 
 // UnmountDeviceFlow umount device, clean device and remove mountpoint folder
-func (b *blockDeviceMounterUtils) UnmountDeviceFlow(devicePath string) error {
+func (b *blockDeviceMounterUtils) UnmountDeviceFlow(devicePath string, volumeWwn string) error {
 	// TODO consider also to receive the mountpoint(not only the devicepath), so the umount will use the mountpoint instead of the devicepath for future support double mounting of the same device.
 	defer b.logger.Trace(logs.INFO, logs.Args{{"devicePath", devicePath}})
 
-	err := b.blockDeviceUtils.UmountFs(devicePath)
+	err := b.blockDeviceUtils.UmountFs(devicePath, volumeWwn)
 	if err != nil {
 		return b.logger.ErrorRet(err, "UmountFs failed")
 	}

--- a/remote/mounter/block_device_mounter_utils/block_device_utils_mounter_test.go
+++ b/remote/mounter/block_device_mounter_utils/block_device_utils_mounter_test.go
@@ -277,14 +277,14 @@ var _ = Describe("block_device_mounter_utils_test", func() {
 	Context(".UnmountDeviceFlow", func() {
 		It("should fail if unmount failed", func() {
 			fakeBlockDeviceUtils.UmountFsReturns(callErr)
-			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device")
+			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device", "")
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(callErr))
 		})
 		It("should fail if Cleanup failed", func() {
 			fakeBlockDeviceUtils.UmountFsReturns(nil)
 			fakeBlockDeviceUtils.CleanupReturns(callErr)
-			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device")
+			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device", "")
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(callErr))
 			Expect(fakeBlockDeviceUtils.CleanupCallCount()).To(Equal(1))
@@ -292,7 +292,7 @@ var _ = Describe("block_device_mounter_utils_test", func() {
 		It("should succees if all is cool", func() {
 			fakeBlockDeviceUtils.UmountFsReturns(nil)
 			fakeBlockDeviceUtils.CleanupReturns(nil)
-			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device")
+			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeBlockDeviceUtils.CleanupCallCount()).To(Equal(1))
 		})

--- a/remote/mounter/block_device_mounter_utils/block_device_utils_mounter_test.go
+++ b/remote/mounter/block_device_mounter_utils/block_device_utils_mounter_test.go
@@ -277,14 +277,14 @@ var _ = Describe("block_device_mounter_utils_test", func() {
 	Context(".UnmountDeviceFlow", func() {
 		It("should fail if unmount failed", func() {
 			fakeBlockDeviceUtils.UmountFsReturns(callErr)
-			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device", "")
+			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device", "6001738CFC9035EA0000000000795164")
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(callErr))
 		})
 		It("should fail if Cleanup failed", func() {
 			fakeBlockDeviceUtils.UmountFsReturns(nil)
 			fakeBlockDeviceUtils.CleanupReturns(callErr)
-			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device", "")
+			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device", "6001738CFC9035EA0000000000795164")
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(callErr))
 			Expect(fakeBlockDeviceUtils.CleanupCallCount()).To(Equal(1))
@@ -292,7 +292,7 @@ var _ = Describe("block_device_mounter_utils_test", func() {
 		It("should succees if all is cool", func() {
 			fakeBlockDeviceUtils.UmountFsReturns(nil)
 			fakeBlockDeviceUtils.CleanupReturns(nil)
-			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device", "")
+			err = blockDeviceMounterUtils.UnmountDeviceFlow("fake_device", "6001738CFC9035EA0000000000795164")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fakeBlockDeviceUtils.CleanupCallCount()).To(Equal(1))
 		})

--- a/remote/mounter/block_device_mounter_utils/resources.go
+++ b/remote/mounter/block_device_mounter_utils/resources.go
@@ -21,5 +21,5 @@ type BlockDeviceMounterUtils interface {
 	RescanAll(withISCSI bool, wwn string, rescanForCleanUp bool) error
 	MountDeviceFlow(devicePath string, fsType string, mountPoint string) error
 	Discover(volumeWwn string, deepDiscovery bool) (string, error)
-	UnmountDeviceFlow(devicePath string) error
+	UnmountDeviceFlow(devicePath string, volumeWwn string) error
 }

--- a/remote/mounter/block_device_utils/block_device_utils_test.go
+++ b/remote/mounter/block_device_utils/block_device_utils_test.go
@@ -617,7 +617,7 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 		It("UmountFs succeeds", func() {
 			mpoint := "/dev/mapper/mpoint"
 			fakeExec.ExecuteReturnsOnCall(0, nil, nil) // the umount command
-			err = bdUtils.UmountFs(mpoint)
+			err = bdUtils.UmountFs(mpoint, "")
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
 
@@ -633,7 +633,7 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 `
 			fakeExec.ExecuteReturnsOnCall(0, nil, cmdErr)                         // the umount command should fail
 			fakeExec.ExecuteWithTimeoutReturnsOnCall(0, []byte(mountOutput), nil) // mount for isMounted
-			err = bdUtils.UmountFs(mpoint)
+			err = bdUtils.UmountFs(mpoint, "")
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
 			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
@@ -645,7 +645,7 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 		It("UmountFs fails if umount command missing", func() {
 			mpoint := "/dev/mapper/mpoint"
 			fakeExec.IsExecutableReturns(cmdErr)
-			err = bdUtils.UmountFs(mpoint)
+			err = bdUtils.UmountFs(mpoint, "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
 			Expect(fakeExec.ExecuteCallCount()).To(Equal(0))
@@ -654,7 +654,7 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 			mpoint := "mpoint"
 			fakeExec.ExecuteReturns([]byte{}, cmdErr)
 			fakeExec.ExecuteWithTimeoutReturns([]byte{}, cmdErr)
-			err = bdUtils.UmountFs(mpoint)
+			err = bdUtils.UmountFs(mpoint, "")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
 		})

--- a/remote/mounter/block_device_utils/block_device_utils_test.go
+++ b/remote/mounter/block_device_utils/block_device_utils_test.go
@@ -617,7 +617,7 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 		It("UmountFs succeeds", func() {
 			mpoint := "/dev/mapper/mpoint"
 			fakeExec.ExecuteReturnsOnCall(0, nil, nil) // the umount command
-			err = bdUtils.UmountFs(mpoint, "")
+			err = bdUtils.UmountFs(mpoint, "6001738CFC9035EA0000000000795164")
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
 
@@ -633,7 +633,7 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 `
 			fakeExec.ExecuteReturnsOnCall(0, nil, cmdErr)                         // the umount command should fail
 			fakeExec.ExecuteWithTimeoutReturnsOnCall(0, []byte(mountOutput), nil) // mount for isMounted
-			err = bdUtils.UmountFs(mpoint, "")
+			err = bdUtils.UmountFs(mpoint, "6001738CFC9035EA0000000000795164")
 			Expect(err).To(Not(HaveOccurred()))
 			Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
 			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
@@ -645,7 +645,7 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 		It("UmountFs fails if umount command missing", func() {
 			mpoint := "/dev/mapper/mpoint"
 			fakeExec.IsExecutableReturns(cmdErr)
-			err = bdUtils.UmountFs(mpoint, "")
+			err = bdUtils.UmountFs(mpoint, "6001738CFC9035EA0000000000795164")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
 			Expect(fakeExec.ExecuteCallCount()).To(Equal(0))
@@ -654,7 +654,7 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 			mpoint := "mpoint"
 			fakeExec.ExecuteReturns([]byte{}, cmdErr)
 			fakeExec.ExecuteWithTimeoutReturns([]byte{}, cmdErr)
-			err = bdUtils.UmountFs(mpoint, "")
+			err = bdUtils.UmountFs(mpoint, "6001738CFC9035EA0000000000795164")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
 		})

--- a/remote/mounter/block_device_utils/fs.go
+++ b/remote/mounter/block_device_utils/fs.go
@@ -83,6 +83,7 @@ func (b *blockDeviceUtils) MountFs(mpath string, mpoint string) error {
 }
 
 func (b *blockDeviceUtils) UmountFs(mpoint string, volumeWwn string) error {
+	// volumeWWN param is only used for logging - for the XAVI automation idempotent tests
 	// Execute unmount operation (skip, if mpoint its already unmounted)
 
 	defer b.logger.Trace(logs.DEBUG)()

--- a/remote/mounter/block_device_utils/fs.go
+++ b/remote/mounter/block_device_utils/fs.go
@@ -82,7 +82,7 @@ func (b *blockDeviceUtils) MountFs(mpath string, mpoint string) error {
 	return nil
 }
 
-func (b *blockDeviceUtils) UmountFs(mpoint string) error {
+func (b *blockDeviceUtils) UmountFs(mpoint string, volumeWwn string) error {
 	// Execute unmount operation (skip, if mpoint its already unmounted)
 
 	defer b.logger.Trace(logs.DEBUG)()
@@ -98,7 +98,7 @@ func (b *blockDeviceUtils) UmountFs(mpoint string) error {
 			return _err
 		}
 		if !isMounted {
-			b.logger.Info("Device already unmounted.", logs.Args{{"mpoint", mpoint}})
+			b.logger.Info("Idempotent issue encountered - Device already unmounted.", logs.Args{{"mpath-device", mpoint}, {"volume-wwn", volumeWwn}})
 			return nil
 		}
 		return b.logger.ErrorRet(&commandExecuteError{umountCmd, err}, "failed")

--- a/remote/mounter/block_device_utils/resources.go
+++ b/remote/mounter/block_device_utils/resources.go
@@ -34,7 +34,7 @@ type BlockDeviceUtils interface {
 	CheckFs(mpath string) (bool, error)
 	MakeFs(mpath string, fsType string) error
 	MountFs(mpath string, mpoint string) error
-	UmountFs(mpoint string) error
+	UmountFs(mpoint string, volumeWwn string) error
 	IsDeviceMounted(devPath string) (bool, []string, error)
 	IsDirAMountPoint(dirPath string) (bool, []string, error)
 }

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -111,7 +111,7 @@ func (s *scbeMounter) Unmount(unmountRequest resources.UnmountRequest) error {
         }
 	}
 	if !skipUnmountFlow{
-		if err := s.blockDeviceMounterUtils.UnmountDeviceFlow(devicePath); err != nil {
+		if err := s.blockDeviceMounterUtils.UnmountDeviceFlow(devicePath, volumeWWN); err != nil {
 			return s.logger.ErrorRet(err, "UnmountDeviceFlow failed", logs.Args{{"devicePath", devicePath}})
 		}
 	}


### PR DESCRIPTION
added a log message to indicate that a device was already unmounted. 
as part of this message we needed to add the volume WWN (to enable the automation to work and check this case) so some changes in the API were made to support this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/233)
<!-- Reviewable:end -->
