### PR TITLE
UB-1407: added timeouts to umount operations

### DIFF
--- a/remote/mounter/block_device_utils/block_device_utils_test.go
+++ b/remote/mounter/block_device_utils/block_device_utils_test.go
@@ -47,16 +47,16 @@ var _ = Describe("block_device_utils_test", func() {
 		It("Rescan ISCSI calls 'sudo iscsiadm -m session --rescan'", func() {
 			err = bdUtils.Rescan(block_device_utils.ISCSI)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
-			cmd, args := fakeExec.ExecuteArgsForCall(0)
+			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
+			_, cmd, args := fakeExec.ExecuteWithTimeoutArgsForCall(0)
 			Expect(cmd).To(Equal("iscsiadm"))
 			Expect(args).To(Equal([]string{"-m", "session", "--rescan"}))
 		})
 		It("Rescan SCSI calls 'sudo rescan-scsi-bus -r'", func() {
 			err = bdUtils.Rescan(block_device_utils.SCSI)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
-			cmd, args := fakeExec.ExecuteArgsForCall(0)
+			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
+			_, cmd, args := fakeExec.ExecuteWithTimeoutArgsForCall(0)
 			Expect(cmd).To(Equal("rescan-scsi-bus"))
 			Expect(args).To(Equal([]string{"-r"}))
 		})
@@ -73,18 +73,18 @@ var _ = Describe("block_device_utils_test", func() {
 			fakeExec.IsExecutableReturns(cmdErr)
 			err = bdUtils.Rescan(block_device_utils.SCSI)
 			Expect(err).To(HaveOccurred())
-			Expect(fakeExec.ExecuteCallCount()).To(Equal(0))
+			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(0))
 			Expect(fakeExec.IsExecutableCallCount()).To(Equal(2))
 			Expect(fakeExec.IsExecutableArgsForCall(0)).To(Equal("rescan-scsi-bus"))
 			Expect(fakeExec.IsExecutableArgsForCall(1)).To(Equal("rescan-scsi-bus.sh"))
 		})
 		It("Rescan ISCSI fails if iscsiadm execution fails", func() {
-			fakeExec.ExecuteReturns([]byte{}, cmdErr)
+			fakeExec.ExecuteWithTimeoutReturns([]byte{}, cmdErr)
 			err = bdUtils.Rescan(block_device_utils.ISCSI)
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
 		})
 		It("Rescan SCSI fails if rescan-scsi-bus execution fails", func() {
-			fakeExec.ExecuteReturns([]byte{}, cmdErr)
+			fakeExec.ExecuteWithTimeoutReturns([]byte{}, cmdErr)
 			err = bdUtils.Rescan(block_device_utils.SCSI)
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
 		})
@@ -132,18 +132,17 @@ var _ = Describe("block_device_utils_test", func() {
 							Vendor Specific Identifier: 0xcfc9035eb
 							Vendor Specific Identifier Extension: 0xcea5f6
 							[%s]`, volumeId)
-			fakeExec.ExecuteReturnsOnCall(0, []byte(fmt.Sprintf("%s (%s) dm-1", result, volumeId)),
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(0, []byte(fmt.Sprintf("%s (%s) dm-1", result, volumeId)),
 				nil)
-			fakeExec.ExecuteWithTimeoutReturns([]byte(fmt.Sprintf("%s", inq_result)), nil) // for getWwnByScsiInq
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(1, []byte(fmt.Sprintf("%s", inq_result)), nil) // for getWwnByScsiInq
 			mpath, err := bdUtils.Discover(strings.TrimPrefix(volumeId, "0x"), true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mpath).To(Equal("/dev/mapper/" + result))
-			Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
-			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
-			cmd, args := fakeExec.ExecuteArgsForCall(0)
+			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(2))
+			_, cmd, args := fakeExec.ExecuteWithTimeoutArgsForCall(0)
 			Expect(cmd).To(Equal("multipath"))
 			Expect(args).To(Equal([]string{"-ll"}))
-			_, cmd, args = fakeExec.ExecuteWithTimeoutArgsForCall(0)
+			_, cmd, args = fakeExec.ExecuteWithTimeoutArgsForCall(1)
 			Expect(cmd).To(Equal("sg_inq"))
 			Expect(args).To(Equal([]string{"-p", "0x83", "/dev/mapper/mpath"}))
 		})
@@ -159,7 +158,7 @@ var _ = Describe("block_device_utils_test", func() {
 		})
 		It("Discover fails if multipath -ll command fails", func() {
 			volumeId := "volume-id"
-			fakeExec.ExecuteReturns([]byte{}, cmdErr)
+			fakeExec.ExecuteWithTimeoutReturns([]byte{}, cmdErr)
 			_, err := bdUtils.Discover(volumeId, true)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
@@ -176,15 +175,15 @@ var _ = Describe("block_device_utils_test", func() {
 							Vendor Specific Identifier: 0xcfc9035eb
 							Vendor Specific Identifier Extension: 0xcea5f6
 							[%s]`, wrongVolumeId)
-			fakeExec.ExecuteReturnsOnCall(0, []byte(fmt.Sprintf("%s (%s) dm-1", result, volumeId)),
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(0, []byte(fmt.Sprintf("%s (%s) dm-1", result, volumeId)),
 				nil)
-			fakeExec.ExecuteWithTimeoutReturns([]byte(fmt.Sprintf("%s", inq_result)), nil) // for getWwnByScsiInq
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(1, []byte(fmt.Sprintf("%s", inq_result)), nil) // for getWwnByScsiInq
 			_, err := bdUtils.Discover(strings.TrimPrefix(volumeId, "0x"), true)
 			Expect(err).To(HaveOccurred())
-			cmd, args := fakeExec.ExecuteArgsForCall(0)
+			_, cmd, args := fakeExec.ExecuteWithTimeoutArgsForCall(0)
 			Expect(cmd).To(Equal("multipath"))
 			Expect(args).To(Equal([]string{"-ll"}))
-			_, cmd, args = fakeExec.ExecuteWithTimeoutArgsForCall(0)
+			_, cmd, args = fakeExec.ExecuteWithTimeoutArgsForCall(1)
 			Expect(cmd).To(Equal("sg_inq"))
 			Expect(args).To(Equal([]string{"-p", "0x83", "/dev/mapper/mpath"}))
 		})
@@ -332,11 +331,11 @@ mpathhb (36001738cfc9035eb0000000000cea###) dm-3 ##,##
 			mpath := "mpath"
 			err = bdUtils.Cleanup(mpath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(fakeExec.ExecuteCallCount()).To(Equal(2))
-			cmd1, args1 := fakeExec.ExecuteArgsForCall(0)
+			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(2))
+			_, cmd1, args1 := fakeExec.ExecuteWithTimeoutArgsForCall(0)
 			Expect(cmd1).To(Equal("dmsetup"))
 			Expect(args1).To(Equal([]string{"message", mpath, "0", "fail_if_no_path"}))
-			cmd2, args2 := fakeExec.ExecuteArgsForCall(1)
+			_, cmd2, args2 := fakeExec.ExecuteWithTimeoutArgsForCall(1)
 			Expect(cmd2).To(Equal("multipath"))
 			Expect(args2).To(Equal([]string{"-f", mpath}))
 		})
@@ -367,7 +366,7 @@ mpathhb (36001738cfc9035eb0000000000cea###) dm-3 ##,##
 		})
 		It("Cleanup fails if dmsetup command fails", func() {
 			mpath := "mpath"
-			fakeExec.ExecuteReturns([]byte{}, cmdErr)
+			fakeExec.ExecuteWithTimeoutReturns([]byte{}, cmdErr)
 			err = bdUtils.Cleanup(mpath)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
@@ -382,7 +381,7 @@ mpathhb (36001738cfc9035eb0000000000cea###) dm-3 ##,##
 		})
 		It("Cleanup fails if multipath command fails", func() {
 			mpath := "mpath"
-			fakeExec.ExecuteReturnsOnCall(1, []byte{}, cmdErr)
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(1, []byte{}, cmdErr)
 			err = bdUtils.Cleanup(mpath)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
@@ -619,9 +618,8 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 			fakeExec.ExecuteReturnsOnCall(0, nil, nil) // the umount command
 			err = bdUtils.UmountFs(mpoint)
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
-
-			cmd, args := fakeExec.ExecuteArgsForCall(0)
+			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
+			_, cmd, args := fakeExec.ExecuteWithTimeoutArgsForCall(0)
 			Expect(cmd).To(Equal("umount"))
 			Expect(args).To(Equal([]string{mpoint}))
 		})
@@ -631,15 +629,14 @@ wrong format on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 /XXX/mpoint on /ubiquity/mpoint type ext4 (rw,relatime,data=ordered)
 /dev/mapper/yyy on /ubiquity/yyy type ext4 (rw,relatime,data=ordered)
 `
-			fakeExec.ExecuteReturnsOnCall(0, nil, cmdErr)                         // the umount command should fail
-			fakeExec.ExecuteWithTimeoutReturnsOnCall(0, []byte(mountOutput), nil) // mount for isMounted
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(0, nil, cmdErr)                         // the umount command should fail
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(1, []byte(mountOutput), nil) // mount for isMounted
 			err = bdUtils.UmountFs(mpoint)
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(fakeExec.ExecuteCallCount()).To(Equal(1))
-			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
-			cmd, _ := fakeExec.ExecuteArgsForCall(0)
+			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(2))
+			_, cmd, _ := fakeExec.ExecuteWithTimeoutArgsForCall(0)
 			Expect(cmd).To(Equal("umount")) // first check is the umount
-			_, cmd, _ = fakeExec.ExecuteWithTimeoutArgsForCall(0)
+			_, cmd, _ = fakeExec.ExecuteWithTimeoutArgsForCall(1)
 			Expect(cmd).To(Equal("mount")) // second check is the umount
 		})
 		It("UmountFs fails if umount command missing", func() {

--- a/remote/mounter/block_device_utils/fs.go
+++ b/remote/mounter/block_device_utils/fs.go
@@ -92,7 +92,7 @@ func (b *blockDeviceUtils) UmountFs(mpoint string) error {
 	}
 
 	args := []string{mpoint}
-	if _, err := b.exec.Execute(umountCmd, args); err != nil {
+	if _, err := b.exec.ExecuteWithTimeout(30*1000, umountCmd, args); err != nil {
 		isMounted, _, _err := b.IsDeviceMounted(mpoint)
 		if _err != nil {
 			return _err

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -27,7 +27,7 @@ import (
 )
 
 const multipathCmd = "multipath"
-const MultipathTimeout = 10*1000
+const MultipathTimeout = 60*1000
 
 func (b *blockDeviceUtils) ReloadMultipath() error {
 	defer b.logger.Trace(logs.DEBUG)()
@@ -57,7 +57,7 @@ func (b *blockDeviceUtils) Discover(volumeWwn string, deepDiscovery bool) (strin
 		return "", b.logger.ErrorRet(&commandNotFoundError{multipathCmd, err}, "failed")
 	}
 	args := []string{"-ll"}
-	outputBytes, err := b.exec.Execute(multipathCmd, args)
+	outputBytes, err := b.exec.ExecuteWithTimeout(20*1000, multipathCmd, args)
 	if err != nil {
 		return "", b.logger.ErrorRet(&commandExecuteError{multipathCmd, err}, "failed")
 	}
@@ -231,6 +231,7 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 
 func (b *blockDeviceUtils) Cleanup(mpath string) error {
 	defer b.logger.Trace(logs.DEBUG)()
+	cleanupTimeout := 30*1000
 	dev := path.Base(mpath)
 
 	_, err := b.exec.Stat(mpath)
@@ -251,14 +252,14 @@ func (b *blockDeviceUtils) Cleanup(mpath string) error {
 	}
 
 	args := []string{"message", dev, "0", "fail_if_no_path"}
-	if _, err := b.exec.Execute(dmsetupCmd, args); err != nil {
+	if _, err := b.exec.ExecuteWithTimeout(cleanupTimeout, dmsetupCmd, args); err != nil {
 		return b.logger.ErrorRet(&commandExecuteError{dmsetupCmd, err}, "failed")
 	}
 	if err := b.exec.IsExecutable(multipathCmd); err != nil {
 		return b.logger.ErrorRet(&commandNotFoundError{multipathCmd, err}, "failed")
 	}
 	args = []string{"-f", dev}
-	if _, err := b.exec.Execute(multipathCmd, args); err != nil {
+	if _, err := b.exec.ExecuteWithTimeout(cleanupTimeout, multipathCmd, args); err != nil {
 		return b.logger.ErrorRet(&commandExecuteError{multipathCmd, err}, "failed")
 	}
 	b.logger.Info("flushed", logs.Args{{"mpath", mpath}})

--- a/remote/mounter/block_device_utils/rescan.go
+++ b/remote/mounter/block_device_utils/rescan.go
@@ -41,7 +41,7 @@ func (b *blockDeviceUtils) RescanISCSI() error {
 		return b.logger.ErrorRet(&commandNotFoundError{rescanCmd, err}, "failed")
 	}
 	args := []string{"-m", "session", "--rescan"}
-	if _, err := b.exec.Execute(rescanCmd, args); err != nil {
+	if _, err := b.exec.ExecuteWithTimeout(1*60*1000, rescanCmd, args); err != nil {
 		return b.logger.ErrorRet(&commandExecuteError{rescanCmd, err}, "failed")
 	}
 	return nil
@@ -61,7 +61,7 @@ func (b *blockDeviceUtils) RescanSCSI() error {
 		return b.logger.ErrorRet(&commandNotFoundError{commands[0], errors.New("")}, "failed")
 	}
 	args := []string{"-r"} // TODO should use -r only in clean up
-	if _, err := b.exec.Execute(rescanCmd, args); err != nil {
+	if _, err := b.exec.ExecuteWithTimeout(2*60*1000, rescanCmd, args); err != nil {
 		return b.logger.ErrorRet(&commandExecuteError{rescanCmd, err}, "failed")
 	}
 	return nil


### PR DESCRIPTION
added timeout to some commands as part of the unmount process as follows:

unmount (timeout 30s)
clean up command : dmsetup and multipath -f   (each should be with timeout of 30s)
multipath -ll  (timeout 20s)
multipath -r  (timeout 60s)
rescan -r (timeout 2 minutes)
iscsiadm rescan (timeout 1 minutes)
