### PR TITLE
Support S390X images in Ubiquity CI helper scripts

### DIFF
--- a/scripts/helper_to_push_ubiquity_images_and_manifests.sh
+++ b/scripts/helper_to_push_ubiquity_images_and_manifests.sh
@@ -3,7 +3,7 @@
 # ----------------------------------------------------------------
 # This script is for internal use in CI
 # The script push all ubiquity images from internal registry to external registry.
-# Images for amd64 and ppc64le for each ubiquity image : ubiquity, ubiquity-db, flex and provisioner.
+# Images for amd64, ppc64le and s390x for each ubiquity image : ubiquity, ubiquity-db, flex and provisioner.
 # It also creates and pushes relevant manifests per architecture into the external repository.
 # The script validates the whole process. If something gets wrong the script will fail with error.
 # Pre-requisites:
@@ -14,10 +14,44 @@
 #    5. Scripts input comes from environment variables, see ubiquity_*_envs and optional TAG_LATEST
 # ----------------------------------------------------------------
 
-ubiquity_envs="in_UBIQUITY_IMAGE_AMD64 out_UBIQUITY_IMAGE_AMD64 in_UBIQUITY_IMAGE_PPC64LE out_UBIQUITY_IMAGE_PPC64LE out_UBIQUITY_IMAGE_MULTIARCH"
-ubiquity_db_envs="in_UBIQUITY_DB_IMAGE_AMD64 out_UBIQUITY_DB_IMAGE_AMD64 in_UBIQUITY_DB_IMAGE_PPC64LE out_UBIQUITY_DB_IMAGE_PPC64LE out_UBIQUITY_DB_IMAGE_MULTIARCH"
-ubiquity_provisioner_envs="in_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64 out_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64 in_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE out_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE out_UBIQUITY_K8S_PROVISIONER_IMAGE_MULTIARCH"
-ubiquity_flex_envs="in_UBIQUITY_K8S_FLEX_IMAGE_AMD64 out_UBIQUITY_K8S_FLEX_IMAGE_AMD64 in_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE out_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE out_UBIQUITY_K8S_FLEX_IMAGE_MULTIARCH"
+function push_arch_images_and_create_manifest_for_app()
+{
+    # This function push <app> arch images(X, P and Z) from internal registry to external registry and then create manifest for them on the external registry.
+    # Function arguments :
+    #   <app name>
+    #   <in_app_image_AMD64>   <out_app_image_AMD64>
+    #   <in_app_image_PPC64LE> <out_app_image_PPC64LE>
+    #   <in_app_image_S390X>   <out_app_image_S390X>
+    #   <out_app_image_MULTIARCH>
+    #   <tag_LATEST>
+
+
+    app_name="$1"
+    in_app_image_AMD64="$2"
+    out_app_image_AMD64="$3"
+    in_app_image_PPC64LE="$4"
+    out_app_image_PPC64LE="$5"
+    in_app_image_S390X="$6"
+    out_app_image_S390X="$7"
+    out_app_image_MULTIARCH="$8"
+    tag_LATEST="$9"
+
+    echo ""
+    echo "Start to push $app_name images and manifest..."
+    $HELPER_PUSH_IMAGE $in_app_image_AMD64                 $out_app_image_AMD64         $tag_LATEST
+    $HELPER_PUSH_IMAGE $in_app_image_PPC64LE               $out_app_image_PPC64LE       $tag_LATEST
+    $HELPER_PUSH_IMAGE $in_app_image_S390X                 $out_app_image_S390X         $tag_LATEST
+    $HELPER_PUSH_MANIFEST $out_app_image_MULTIARCH   $out_app_image_AMD64  $out_app_image_PPC64LE  $out_app_image_S390X
+    if [ -n "$tag_LATEST" ]; then
+        latest_external_image=`echo $out_app_image_MULTIARCH | sed "s|^\(.*/.*:\)\(.*\)$|\1$tag_LATEST|"` # replace tag with $tag_LATEST
+        $HELPER_PUSH_MANIFEST $latest_external_image   $out_app_image_AMD64  $out_app_image_PPC64LE  $out_app_image_S390X no
+    fi
+}
+
+ubiquity_envs="in_UBIQUITY_IMAGE_AMD64 out_UBIQUITY_IMAGE_AMD64 in_UBIQUITY_IMAGE_PPC64LE out_UBIQUITY_IMAGE_PPC64LE in_UBIQUITY_IMAGE_S390X out_UBIQUITY_IMAGE_S390X out_UBIQUITY_IMAGE_MULTIARCH"
+ubiquity_db_envs="in_UBIQUITY_DB_IMAGE_AMD64 out_UBIQUITY_DB_IMAGE_AMD64 in_UBIQUITY_DB_IMAGE_PPC64LE out_UBIQUITY_DB_IMAGE_PPC64LE in_UBIQUITY_DB_IMAGE_S390X out_UBIQUITY_DB_IMAGE_S390X out_UBIQUITY_DB_IMAGE_MULTIARCH"
+ubiquity_provisioner_envs="in_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64 out_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64 in_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE out_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE in_UBIQUITY_K8S_PROVISIONER_IMAGE_S390X out_UBIQUITY_K8S_PROVISIONER_IMAGE_S390X out_UBIQUITY_K8S_PROVISIONER_IMAGE_MULTIARCH"
+ubiquity_flex_envs="in_UBIQUITY_K8S_FLEX_IMAGE_AMD64 out_UBIQUITY_K8S_FLEX_IMAGE_AMD64 in_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE out_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE in_UBIQUITY_K8S_FLEX_IMAGE_S390X out_UBIQUITY_K8S_FLEX_IMAGE_S390X out_UBIQUITY_K8S_FLEX_IMAGE_MULTIARCH"
 
 HELPER_PUSH_IMAGE=./helper_to_push_docker_image.sh
 HELPER_PUSH_MANIFEST=./helper_to_push_docker_manifest.sh
@@ -32,48 +66,11 @@ done
 
 echo "TAG_LATEST=$TAG_LATEST"
 
-echo ""
-echo "Start to push Ubiquity images and manifests..."
-$HELPER_PUSH_IMAGE $in_UBIQUITY_IMAGE_AMD64                 $out_UBIQUITY_IMAGE_AMD64         $TAG_LATEST
-$HELPER_PUSH_IMAGE $in_UBIQUITY_IMAGE_PPC64LE               $out_UBIQUITY_IMAGE_PPC64LE       $TAG_LATEST
-$HELPER_PUSH_MANIFEST $out_UBIQUITY_IMAGE_MULTIARCH   $out_UBIQUITY_IMAGE_AMD64  $out_UBIQUITY_IMAGE_PPC64LE
-if [ -n "$TAG_LATEST" ]; then
-    latest_external_image=`echo $out_UBIQUITY_IMAGE_MULTIARCH | sed "s|^\(.*/.*:\)\(.*\)$|\1$TAG_LATEST|"` # replace tag with $TAG_LATEST
-    $HELPER_PUSH_MANIFEST $latest_external_image   $out_UBIQUITY_IMAGE_AMD64  $out_UBIQUITY_IMAGE_PPC64LE no
-fi
 
-echo ""
-echo "Start to push Ubiquity DB images and manifests..."
-$HELPER_PUSH_IMAGE $in_UBIQUITY_DB_IMAGE_AMD64                $out_UBIQUITY_DB_IMAGE_AMD64             $TAG_LATEST
-$HELPER_PUSH_IMAGE $in_UBIQUITY_DB_IMAGE_PPC64LE              $out_UBIQUITY_DB_IMAGE_PPC64LE           $TAG_LATEST
-$HELPER_PUSH_MANIFEST $out_UBIQUITY_DB_IMAGE_MULTIARCH   $out_UBIQUITY_DB_IMAGE_AMD64  $out_UBIQUITY_DB_IMAGE_PPC64LE $TAG_LATEST
-if [ -n "$TAG_LATEST" ]; then
-    latest_external_image=`echo $out_UBIQUITY_DB_IMAGE_MULTIARCH | sed "s|^\(.*/.*:\)\(.*\)$|\1$TAG_LATEST|"` # replace tag with $TAG_LATEST
-    $HELPER_PUSH_MANIFEST $latest_external_image   $out_UBIQUITY_DB_IMAGE_AMD64  $out_UBIQUITY_DB_IMAGE_PPC64LE no
-fi
-
-
-echo ""
-echo "Start to push Ubiquity provisioner images and manifests..."
-$HELPER_PUSH_IMAGE $in_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64                 $out_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64        $TAG_LATEST
-$HELPER_PUSH_IMAGE $in_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE               $out_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE      $TAG_LATEST
-$HELPER_PUSH_MANIFEST $out_UBIQUITY_K8S_PROVISIONER_IMAGE_MULTIARCH   $out_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64  $out_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE  $TAG_LATEST
-if [ -n "$TAG_LATEST" ]; then
-    latest_external_image=`echo $out_UBIQUITY_K8S_PROVISIONER_IMAGE_MULTIARCH | sed "s|^\(.*/.*:\)\(.*\)$|\1$TAG_LATEST|"` # replace tag with $TAG_LATEST
-    $HELPER_PUSH_MANIFEST $latest_external_image   $out_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64  $out_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE no
-fi
-
-
-echo ""
-echo "Start to push Ubiquity flex images and manifests..."
-$HELPER_PUSH_IMAGE $in_UBIQUITY_K8S_FLEX_IMAGE_AMD64                 $out_UBIQUITY_K8S_FLEX_IMAGE_AMD64     $TAG_LATEST
-$HELPER_PUSH_IMAGE $in_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE               $out_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE   $TAG_LATEST
-$HELPER_PUSH_MANIFEST $out_UBIQUITY_K8S_FLEX_IMAGE_MULTIARCH   $out_UBIQUITY_K8S_FLEX_IMAGE_AMD64  $out_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE   $TAG_LATEST
-if [ -n "$TAG_LATEST" ]; then
-    latest_external_image=`echo $out_UBIQUITY_K8S_FLEX_IMAGE_MULTIARCH | sed "s|^\(.*/.*:\)\(.*\)$|\1$TAG_LATEST|"` # replace tag with $TAG_LATEST
-    $HELPER_PUSH_MANIFEST $latest_external_image   $out_UBIQUITY_K8S_FLEX_IMAGE_AMD64  $out_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE  no
-fi
-
+push_arch_images_and_create_manifest_for_app "Ubiquity"              $in_UBIQUITY_IMAGE_AMD64                 $out_UBIQUITY_IMAGE_AMD64                          $in_UBIQUITY_IMAGE_PPC64LE                 $out_UBIQUITY_IMAGE_PPC64LE                          $in_UBIQUITY_IMAGE_S390X                 $out_UBIQUITY_IMAGE_S390X                          $out_UBIQUITY_IMAGE_MULTIARCH                  $TAG_LATEST
+push_arch_images_and_create_manifest_for_app "Ubiquity DB"           $in_UBIQUITY_DB_IMAGE_AMD64              $out_UBIQUITY_DB_IMAGE_AMD64                       $in_UBIQUITY_DB_IMAGE_PPC64LE              $out_UBIQUITY_DB_IMAGE_PPC64LE                       $in_UBIQUITY_DB_IMAGE_S390X              $out_UBIQUITY_DB_IMAGE_S390X                       $out_UBIQUITY_DB_IMAGE_MULTIARCH               $TAG_LATEST
+push_arch_images_and_create_manifest_for_app "Ubiquity provisioner"  $in_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64 $out_UBIQUITY_K8S_PROVISIONER_IMAGE_AMD64          $in_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE $out_UBIQUITY_K8S_PROVISIONER_IMAGE_PPC64LE          $in_UBIQUITY_K8S_PROVISIONER_IMAGE_S390X $out_UBIQUITY_K8S_PROVISIONER_IMAGE_S390X          $out_UBIQUITY_K8S_PROVISIONER_IMAGE_MULTIARCH  $TAG_LATEST
+push_arch_images_and_create_manifest_for_app "Ubiquity flex"         $in_UBIQUITY_K8S_FLEX_IMAGE_AMD64        $out_UBIQUITY_K8S_FLEX_IMAGE_AMD64                 $in_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE        $out_UBIQUITY_K8S_FLEX_IMAGE_PPC64LE                 $in_UBIQUITY_K8S_FLEX_IMAGE_S390X        $out_UBIQUITY_K8S_FLEX_IMAGE_S390X                 $out_UBIQUITY_K8S_FLEX_IMAGE_MULTIARCH         $TAG_LATEST
 
 date
 echo "######################################"


### PR DESCRIPTION
Add support for Ubiquity Z images (s390x architecture) in the helper CI scripts. So the CI scripts will also push s390x ubiqutiy images from an internal registry to external registry, and also create the ubiqutiy docker manifest with the new s390x image architecture (before this PR the helper scripts supported only P and X architecture).

Below the description of the CI scripts changes to support Z images:
1. changes in [helper_to_push_docker_manifest.sh]:
   - The script gets another argument for Z image (in addition to P and X images). 
   - The script pushes also the Z image from internal registry to external registry and creates the manifest with X, P and Z images. 
   - In addition the script validates that the new manifest has 3 different architectures.

2. Changes in [helper_to_push_ubiquity_images_and_manifests.sh]:
   - The script gets new environment variables for Z images (in\out and manifest for ubiquity, ubiquity-db, flex and provisioner). 
   - Run for each ubiqutiy app an additional call to handle ubiqutiy Z images. 
   - Refactor to reduce code duplication for every ubiqutiy app.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/238)
<!-- Reviewable:end -->
