### PR TITLE
Fix/ub-1436 umount when pv does not exist

### DIFF
--- a/web_server/storage_api_handler.go
+++ b/web_server/storage_api_handler.go
@@ -363,7 +363,7 @@ func (h *StorageApiHandler) getBackend(name string) (resources.StorageClient, er
 
 	// get backend name for volume
 	if backendName = h.getBackendName(name); backendName == "" {
-		err := resources.VolumeNotFoundError{name}
+		err := &resources.VolumeNotFoundError{name}
 		return nil, h.logger.ErrorRet(err, "failed")
 	}
 

--- a/web_server/storage_api_handler.go
+++ b/web_server/storage_api_handler.go
@@ -363,7 +363,7 @@ func (h *StorageApiHandler) getBackend(name string) (resources.StorageClient, er
 
 	// get backend name for volume
 	if backendName = h.getBackendName(name); backendName == "" {
-		err := fmt.Errorf("volume %s not found", name)
+		err := resources.VolumeNotFoundError{name}
 		return nil, h.logger.ErrorRet(err, "failed")
 	}
 


### PR DESCRIPTION
the getBackend function in the storage_api_handler was returning the wrong error message and the controller was expecting the right one, so i fixed it to return the correct error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/241)
<!-- Reviewable:end -->
