### PR TITLE
Spectrumscale-epic1 fix for UB-1487,UB-1488,UB-1495

### DIFF
--- a/local/clients.go
+++ b/local/clients.go
@@ -26,12 +26,15 @@ import (
 func GetLocalClients(logger *log.Logger, config resources.UbiquityServerConfig) (map[string]resources.StorageClient, error) {
 	// TODO need to refactor and load all the existing clients automatically (instead of hardcore each one here)
 	clients := make(map[string]resources.StorageClient)
-	ScbeClient, err := scbe.NewScbeLocalClient(config.ScbeConfig)
-	if err != nil {
-		logger.Printf("Not enough params to initialize '%s' client", resources.SCBE)
-	} else {
-		clients[resources.SCBE] = ScbeClient
-	}
+
+	if (config.ScbeConfig.ConnectionInfo.ManagementIP != "") {
+	  ScbeClient, err := scbe.NewScbeLocalClient(config.ScbeConfig)
+	  if err != nil {
+		  logger.Printf("Not enough params to initialize '%s' client", resources.SCBE)
+	  } else {
+		  clients[resources.SCBE] = ScbeClient
+    }
+  }
 
 	if len(clients) == 0 {
 		log.Fatal("No client can be initialized....please check config file")

--- a/local/clients.go
+++ b/local/clients.go
@@ -37,8 +37,8 @@ func GetLocalClients(logger *log.Logger, config resources.UbiquityServerConfig) 
   }
 
 	if len(clients) == 0 {
-		logger.Println("No client can be initialized....please check config file")
-		return nil, fmt.Errorf("No client can be initialized....please check config file")
+		logger.Println("No client can be initialized. Please check ubiquity-configmap parameters")
+		return nil, fmt.Errorf("No client can be initialized. Please check ubiquity-configmap parameters")
 	}
 	return clients, nil
 }

--- a/local/clients.go
+++ b/local/clients.go
@@ -37,7 +37,7 @@ func GetLocalClients(logger *log.Logger, config resources.UbiquityServerConfig) 
   }
 
 	if len(clients) == 0 {
-		log.Fatal("No client can be initialized....please check config file")
+		logger.Println("No client can be initialized....please check config file")
 		return nil, fmt.Errorf("No client can be initialized....please check config file")
 	}
 	return clients, nil

--- a/local/clients_test.go
+++ b/local/clients_test.go
@@ -11,12 +11,12 @@ import (
 
 var _ = Describe("Clients", func() {
 	var (
-		fakeConfig         resources.UbiquityServerConfig
-		fakeScbeConfig     resources.ScbeConfig
-		fakeConnectionInfo resources.ConnectionInfo
-		err                error
-		logger         	   *log.Logger
-		client		   map[string]resources.StorageClient
+		fakeConfig          resources.UbiquityServerConfig
+		fakeScbeConfig      resources.ScbeConfig
+		fakeConnectionInfo  resources.ConnectionInfo
+		err                 error
+		logger              *log.Logger
+		client		        map[string]resources.StorageClient
 	)
 	BeforeEach(func() {
 		logger = log.New(os.Stdout, "ubiquity: ", log.Lshortfile|log.LstdFlags)
@@ -25,12 +25,12 @@ var _ = Describe("Clients", func() {
 	Context(".GetLocalClients", func() {
 	It("should fail when ManagementIP is empty for SCBE backend", func() {
 		fakeConnectionInfo = resources.ConnectionInfo{}
-		fakeScbeConfig 	   = resources.ScbeConfig{ConnectionInfo: fakeConnectionInfo,}
+		fakeScbeConfig	   = resources.ScbeConfig{ConnectionInfo: fakeConnectionInfo,}
 		fakeConfig	   = resources.UbiquityServerConfig{ScbeConfig: fakeScbeConfig,}
 		client, err = local.GetLocalClients(logger, fakeConfig)
 		Expect(client).To(BeNil())
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("No client can be initialized....please check config file"))
-	})	
+		Expect(err.Error()).To(Equal("No client can be initialized. Please check ubiquity-configmap parameters"))
+	})
 	})
 })

--- a/local/clients_test.go
+++ b/local/clients_test.go
@@ -1,0 +1,36 @@
+package local_test
+
+import (
+	"os"
+	"log"
+	"github.com/IBM/ubiquity/resources"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/IBM/ubiquity/local"
+)
+
+var _ = Describe("Clients", func() {
+	var (
+		fakeConfig         resources.UbiquityServerConfig
+		fakeScbeConfig     resources.ScbeConfig
+		fakeConnectionInfo resources.ConnectionInfo
+		err                error
+		logger         	   *log.Logger
+		client		   map[string]resources.StorageClient
+	)
+	BeforeEach(func() {
+		logger = log.New(os.Stdout, "ubiquity: ", log.Lshortfile|log.LstdFlags)
+	})
+
+	Context(".GetLocalClients", func() {
+	It("should fail when ManagementIP is empty for SCBE backend", func() {
+		fakeConnectionInfo = resources.ConnectionInfo{}
+		fakeScbeConfig 	   = resources.ScbeConfig{ConnectionInfo: fakeConnectionInfo,}
+		fakeConfig	   = resources.UbiquityServerConfig{ScbeConfig: fakeScbeConfig,}
+		client, err = local.GetLocalClients(logger, fakeConfig)
+		Expect(client).To(BeNil())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("No client can be initialized....please check config file"))
+	})	
+	})
+})

--- a/local/spectrumscale/connectors/connectors.go
+++ b/local/spectrumscale/connectors/connectors.go
@@ -54,6 +54,17 @@ const (
 )
 
 func GetSpectrumScaleConnector(logger *log.Logger, config resources.SpectrumScaleConfig) (SpectrumScaleConnector, error) {
-	logger.Printf("Initializing SpectrumScale REST connector\n")
-	return NewSpectrumRestV2(logger, config.RestConfig)
+	if config.RestConfig.ManagementIP != "" {
+		logger.Printf("Initializing SpectrumScale REST connector\n")
+		return NewSpectrumRestV2(logger, config.RestConfig)
+	}
+	if config.SshConfig.User != "" && config.SshConfig.Host != "" {
+		if config.SshConfig.Port == "" || config.SshConfig.Port == "0" {
+			config.SshConfig.Port = "22"
+		}
+		logger.Printf("Initializing SpectrumScale SSH connector with sshConfig: %+v\n", config.SshConfig)
+		return NewSpectrumSSH(logger, config.SshConfig)
+	}
+	logger.Println("Initializing SpectrumScale MMCLI Connector")
+	return NewSpectrumMMCLI(logger)
 }

--- a/local/spectrumscale/connectors/connectors.go
+++ b/local/spectrumscale/connectors/connectors.go
@@ -54,17 +54,6 @@ const (
 )
 
 func GetSpectrumScaleConnector(logger *log.Logger, config resources.SpectrumScaleConfig) (SpectrumScaleConnector, error) {
-	if config.RestConfig.Endpoint != "" {
-		logger.Printf("Initializing SpectrumScale REST connector\n")
-		return NewSpectrumRestV2(logger, config.RestConfig)
-	}
-	if config.SshConfig.User != "" && config.SshConfig.Host != "" {
-		if config.SshConfig.Port == "" || config.SshConfig.Port == "0" {
-			config.SshConfig.Port = "22"
-		}
-		logger.Printf("Initializing SpectrumScale SSH connector with sshConfig: %+v\n", config.SshConfig)
-		return NewSpectrumSSH(logger, config.SshConfig)
-	}
-	logger.Println("Initializing SpectrumScale MMCLI Connector")
-	return NewSpectrumMMCLI(logger)
+	logger.Printf("Initializing SpectrumScale REST connector\n")
+	return NewSpectrumRestV2(logger, config.RestConfig)
 }

--- a/local/spectrumscale/connectors/rest.go
+++ b/local/spectrumscale/connectors/rest.go
@@ -36,7 +36,7 @@ type spectrum_rest struct {
 }
 
 func NewSpectrumRest(logger *log.Logger, restConfig resources.RestConfig) (SpectrumScaleConnector, error) {
-	endpoint := restConfig.Endpoint
+	endpoint := fmt.Sprintf("https://%s:%d/", restConfig.ManagementIP, restConfig.Port)
 	user := restConfig.User
 	password := restConfig.Password
 
@@ -48,7 +48,7 @@ func NewSpectrumRest(logger *log.Logger, restConfig resources.RestConfig) (Spect
 }
 
 func NewSpectrumRestWithClient(logger *log.Logger, restConfig resources.RestConfig, client *http.Client) (SpectrumScaleConnector, error) {
-	endpoint := restConfig.Endpoint
+	endpoint := fmt.Sprintf("https://%s:%d/", restConfig.ManagementIP, restConfig.Port)
 	return &spectrum_rest{logger: logger, httpClient: client, endpoint: endpoint}, nil
 }
 

--- a/local/spectrumscale/connectors/rest_v2.go
+++ b/local/spectrumscale/connectors/rest_v2.go
@@ -123,7 +123,7 @@ func (s *spectrumRestV2) AsyncJobCompletion(jobURL string) error {
 
 func NewSpectrumRestV2(logger *log.Logger, restConfig resources.RestConfig) (SpectrumScaleConnector, error) {
 
-	endpoint := restConfig.Endpoint
+	endpoint := fmt.Sprintf("https://%s:%d/", restConfig.ManagementIP, restConfig.Port)
 	user := restConfig.User
 	password := restConfig.Password
 	hostname := restConfig.Hostname
@@ -135,7 +135,7 @@ func NewSpectrumRestV2(logger *log.Logger, restConfig resources.RestConfig) (Spe
 }
 
 func NewspectrumRestV2WithClient(logger *log.Logger, restConfig resources.RestConfig) (SpectrumScaleConnector, *http.Client, error) {
-	endpoint := restConfig.Endpoint
+	endpoint := fmt.Sprintf("https://%s:%d/", restConfig.ManagementIP, restConfig.Port)
 	user := restConfig.User
 	password := restConfig.Password
 	hostname := restConfig.Hostname

--- a/local/spectrumscale/connectors/rest_v2_test.go
+++ b/local/spectrumscale/connectors/rest_v2_test.go
@@ -46,7 +46,8 @@ var _ = Describe("spectrumRestV2", func() {
 		logger = log.New(os.Stdout, "spectrum: ", log.Lshortfile|log.LstdFlags)
 		httpmock.Activate()
 		fakeurl = "http://1.1.1.1:443"
-		restConfig.Endpoint = fakeurl
+		restConfig.ManagementIP = "1.1.1.1"
+		restConfig.Port = 443
 		restConfig.User = "fakeuser"
 		restConfig.Password = "fakepassword"
 		restConfig.Hostname = "fakehostname"

--- a/local/spectrumscale/spectrumscale.go
+++ b/local/spectrumscale/spectrumscale.go
@@ -630,7 +630,7 @@ func (s *spectrumLocalClient) updateDBWithExistingFilesetQuota(filesystem, name,
 		return err
 	}
 
-	if s.config.RestConfig.Endpoint != "" {
+	if s.config.RestConfig.ManagementIP != "" {
 		s.logger.Printf("For REST connector converting quotas to bytes\n")
 		filesetQuotaBytes, err := utils.ConvertToBytes(s.logger, filesetQuota)
 		if err != nil {

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -86,7 +86,7 @@ const DefaultDbSslMode = SslModeVerifyFull
 const DefaultScbeSslMode = SslModeVerifyFull
 const DefaultPluginsSslMode = SslModeVerifyFull
 const SpectrumscaleDefaultPort = 443                              // the default port for SPECTRUM SCALE management
-
+const SpectrumScaleParamPrefix = "SPECTRUMSCALE_"
 
 type SshConfig struct {
 	User string

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -85,6 +85,8 @@ const KeyScbeSslMode = "SCBE_SSL_MODE"
 const DefaultDbSslMode = SslModeVerifyFull
 const DefaultScbeSslMode = SslModeVerifyFull
 const DefaultPluginsSslMode = SslModeVerifyFull
+const SpectrumscaleDefaultPort = 443                              // the default port for SPECTRUM SCALE management
+
 
 type SshConfig struct {
 	User string
@@ -93,10 +95,11 @@ type SshConfig struct {
 }
 
 type RestConfig struct {
-	Endpoint string
-	User     string
-	Password string
-	Hostname string
+	Port          int
+	ManagementIP  string
+	User          string
+	Password      string
+	Hostname      string
 }
 
 type SpectrumNfsRemoteConfig struct {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -225,24 +225,21 @@ func LoadConfig() (resources.UbiquityServerConfig, error) {
 	config.LogLevel = os.Getenv("LOG_LEVEL")
 
 	sscConfig := resources.SpectrumScaleConfig{}
-	sshConfig := resources.SshConfig{}
-	sshConfig.User = os.Getenv("SSC_SSH_USER")
-	sshConfig.Host = os.Getenv("SSC_SSH_HOST")
-	sshConfig.Port = os.Getenv("SSC_SSH_PORT")
-	if sshConfig.User != "" && sshConfig.Host != "" && sshConfig.Port != "" {
-		sscConfig.SshConfig = sshConfig
-	}
 	restConfig := resources.RestConfig{}
-	restConfig.Endpoint = os.Getenv("SSC_REST_ENDPOINT")
-	restConfig.User = os.Getenv("SSC_REST_USER")
-	restConfig.Password = os.Getenv("SSC_REST_PASSWORD")
-	restConfig.Hostname = os.Getenv("SSC_REST_HOSTNAME")
-	if restConfig.User != "" && restConfig.Hostname != "" && restConfig.Password != "" {
-		sscConfig.RestConfig = restConfig
+	restConfig.User = os.Getenv("SPECTRUMSCALE_REST_USER")
+	restConfig.Password = os.Getenv("SPECTRUMSCALE_REST_PASSWORD")
+	restConfig.Hostname = os.Getenv("SPECTRUMSCALE_REST_HOSTNAME")
+	restConfig.ManagementIP = os.Getenv("SPECTRUMSCALE_MANAGEMENT_IP")
+	spectrumscalePort, err := strconv.ParseInt(os.Getenv("SPECTRUMSCALE_MANAGEMENT_PORT"), 0, 32)
+	if err != nil {
+		restConfig.Port = resources.SpectrumscaleDefaultPort
+	} else {
+		restConfig.Port = int(spectrumscalePort)
 	}
-	sscConfig.DefaultFilesystemName = os.Getenv("DEFAULT_FILESYSTEM_NAME")
-	sscConfig.NfsServerAddr = os.Getenv("SSC_NFS_SERVER_ADDRESS")
-	forceDelete, err := strconv.ParseBool(os.Getenv("FORCE_DELETE"))
+	sscConfig.RestConfig = restConfig
+	sscConfig.DefaultFilesystemName = os.Getenv("SPECTRUMSCALE_DEFAULT_FILESYSTEM_NAME")
+	sscConfig.NfsServerAddr = os.Getenv("SPECTRUMSCALE_NFS_SERVER_ADDRESS")
+	forceDelete, err := strconv.ParseBool(os.Getenv("SPECTRUMSCALE_FORCE_DELETE"))
 	if err != nil {
 		sscConfig.ForceDelete = false
 	} else {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -225,21 +225,28 @@ func LoadConfig() (resources.UbiquityServerConfig, error) {
 	config.LogLevel = os.Getenv("LOG_LEVEL")
 
 	sscConfig := resources.SpectrumScaleConfig{}
+	sshConfig := resources.SshConfig{}
+	sshConfig.User = os.Getenv("SSC_SSH_USER")
+	sshConfig.Host = os.Getenv("SSC_SSH_HOST")
+	sshConfig.Port = os.Getenv("SSC_SSH_PORT")
+	if sshConfig.User != "" && sshConfig.Host != "" && sshConfig.Port != "" {
+		sscConfig.SshConfig = sshConfig
+	}
 	restConfig := resources.RestConfig{}
-	restConfig.User = os.Getenv("SPECTRUMSCALE_REST_USER")
-	restConfig.Password = os.Getenv("SPECTRUMSCALE_REST_PASSWORD")
-	restConfig.Hostname = os.Getenv("SPECTRUMSCALE_REST_HOSTNAME")
-	restConfig.ManagementIP = os.Getenv("SPECTRUMSCALE_MANAGEMENT_IP")
-	spectrumscalePort, err := strconv.ParseInt(os.Getenv("SPECTRUMSCALE_MANAGEMENT_PORT"), 0, 32)
+	restConfig.User = os.Getenv(resources.SpectrumScaleParamPrefix + "REST_USER")
+	restConfig.Password = os.Getenv(resources.SpectrumScaleParamPrefix + "REST_PASSWORD")
+	restConfig.Hostname = os.Getenv(resources.SpectrumScaleParamPrefix + "REST_HOSTNAME")
+	restConfig.ManagementIP = os.Getenv(resources.SpectrumScaleParamPrefix + "MANAGEMENT_IP")
+	spectrumscalePort, err := strconv.ParseInt(os.Getenv(resources.SpectrumScaleParamPrefix + "MANAGEMENT_PORT"), 0, 32)
 	if err != nil {
 		restConfig.Port = resources.SpectrumscaleDefaultPort
 	} else {
 		restConfig.Port = int(spectrumscalePort)
 	}
 	sscConfig.RestConfig = restConfig
-	sscConfig.DefaultFilesystemName = os.Getenv("SPECTRUMSCALE_DEFAULT_FILESYSTEM_NAME")
-	sscConfig.NfsServerAddr = os.Getenv("SPECTRUMSCALE_NFS_SERVER_ADDRESS")
-	forceDelete, err := strconv.ParseBool(os.Getenv("SPECTRUMSCALE_FORCE_DELETE"))
+	sscConfig.DefaultFilesystemName = os.Getenv(resources.SpectrumScaleParamPrefix + "DEFAULT_FILESYSTEM_NAME")
+	sscConfig.NfsServerAddr = os.Getenv("SSC_NFS_SERVER_ADDRESS")
+	forceDelete, err := strconv.ParseBool(os.Getenv(resources.SpectrumScaleParamPrefix + "FORCE_DELETE"))
 	if err != nil {
 		sscConfig.ForceDelete = false
 	} else {


### PR DESCRIPTION
UB-1487 : Using ManagementIP and Port instead of accepting URL for endpoint
UB-1488 : Using SPECTRUMSCALE_ prefix instead of SSC_
UB-1495 : Improve the check in backend initilization. Added check for scbe backend. Check for Spectrum Scale will be added later.
Removed MMCLI and MMSSH backend initialization as they are no longer valid
Removed sshconfig from resource.go because it is no longer required
Minor updates in test to use ManagementIP and Port instead of Endpoint

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/243)
<!-- Reviewable:end -->
