### PR TITLE
UB-1501: Upgrade to openssl-1.0.2o-r1 to align with Alpine 3.7 repo updates.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode 
 
 
 FROM alpine:3.7
-RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2o-r0
+RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2o-r1
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity/ubiquity .
 COPY --from=0 /go/src/github.com/IBM/ubiquity/LICENSE .


### PR DESCRIPTION
It seams that openssl-1.0.2o-r0 was removed from the Alpine 3.7 repository (http://dl-cdn.alpinelinux.org/alpine/v3.7/main/). It was replaced to this new version 1.0.2o-r1 in 18-Jul-2018 07:29 (40 days ago).  

So we must update the openssl version in the ubiqutiy Dockerfile in order to successfully build the Ubiquity image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/244)
<!-- Reviewable:end -->
