### PR TITLE
Fix/ub-599 discover by sg_inq should continue scan if bad mpath device

### DIFF
--- a/remote/mounter/block_device_utils/block_device_utils_test.go
+++ b/remote/mounter/block_device_utils/block_device_utils_test.go
@@ -196,7 +196,7 @@ var _ = Describe("block_device_utils_test", func() {
 			_, err := bdUtils.Discover(volumeId, true)
 			Expect(err).To(HaveOccurred())
 		})
-		It("should return actual error when sg_inq command fails", func() {
+		It("should return volume not found when sg_inq command fails", func() {
 			volumeId := "0x6001738cfc9035eb0000000000cea5f6"
 			mpathOutput := `mpathhe (36001738cfc9035eb0000000000cea5f6) dm-3 IBM     ,2810XIV
 							size=19G features='1 queue_if_no_path' hwhandler='0' wp=rw
@@ -209,7 +209,7 @@ var _ = Describe("block_device_utils_test", func() {
 			fakeExec.ExecuteWithTimeoutReturnsOnCall(1, []byte(""),returnError)
 			_, err := bdUtils.Discover(volumeId, true)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(&block_device_utils.CommandExecuteError{"sg_inq",returnError}))
+			Expect(err).To(Equal(&block_device_utils.VolumeNotFoundError{volumeId}))
 		})
 	})
 	Context(".DiscoverBySgInq", func() {
@@ -221,7 +221,7 @@ var _ = Describe("block_device_utils_test", func() {
 							- 34:0:0:1 sdc 8:32 active ready running`
 			volWwn := "0x6001738cfc9035eb0000000000cea5f6"
 			expectedWwn := strings.TrimPrefix(volWwn, "0x")
-			inq_result := fmt.Sprintf(`VPD INQUIRY: Device Identification page
+			inqResult := fmt.Sprintf(`VPD INQUIRY: Device Identification page
 							Designation descriptor number 1, descriptor length: 20
 							designator_type: NAA,  code_set: Binary
 							associated with the addressed logical unit
@@ -229,7 +229,7 @@ var _ = Describe("block_device_utils_test", func() {
 							Vendor Specific Identifier: 0xcfc9035eb
 							Vendor Specific Identifier Extension: 0xcea5f6
 							[%s]`, volWwn)
-			fakeExec.ExecuteWithTimeoutReturns([]byte(fmt.Sprintf("%s", inq_result)), nil)
+			fakeExec.ExecuteWithTimeoutReturns([]byte(fmt.Sprintf("%s", inqResult)), nil)
 			dev, err := bdUtils.DiscoverBySgInq(mpathOutput, expectedWwn)
 			Expect(dev).To(Equal("mpathhe"))
 			Expect(err).ToNot(HaveOccurred())
@@ -237,6 +237,44 @@ var _ = Describe("block_device_utils_test", func() {
 			_, cmd, _ := fakeExec.ExecuteWithTimeoutArgsForCall(0)
 			Expect(cmd).To(Equal("sg_inq"))
 		})
+		
+		It("should return the 3rd mpath device mpathhg", func() {
+			volWwn := "0x6001738cfc9035eb0000000000cea5f6"
+			expectedWwn := strings.TrimPrefix(volWwn, "0x")
+			mpathOutput := fmt.Sprint(`mpathhe (36001738cfc9035eb0000000000cerwr) dm-3 IBM     ,2810XIV
+							size=19G features='1 queue_if_no_path' hwhandler='0' wp=rw
+							-+- policy='service-time 0' prio=1 status=active
+							|- 32:0:0:1 sdb 8:16 fault faulty running
+							- 31:0:0:1 sdc 8:32 fault faulty running
+mpathhf (36001738cfc9035eb0000000000crwrfw24) dm-3 IBM     ,2810XIV
+							size=19G features='1 queue_if_no_path' hwhandler='0' wp=rw
+							-+- policy='service-time 0' prio=1 status=active
+							|- 33:0:0:1 sdb 8:16 fault faulty running
+							- 34:0:0:1 sdc 8:32 fault faulty running
+mpathhg (3%s) dm-3 IBM     ,2810XIV
+							size=19G features='1 queue_if_no_path' hwhandler='0' wp=rw
+							-+- policy='service-time 0' prio=1 status=active
+							|- 33:0:0:1 sdb 8:16 active ready running
+							- 34:0:0:1 sdc 8:32 active ready running`,expectedWwn )
+			inqResult := fmt.Sprintf(`VPD INQUIRY: Device Identification page
+							Designation descriptor number 1, descriptor length: 20
+							designator_type: NAA,  code_set: Binary
+							associated with the addressed logical unit
+							NAA 6, IEEE Company_id: 0x1738
+							Vendor Specific Identifier: 0xcfc9035eb
+							Vendor Specific Identifier Extension: 0xcea5f6
+							[%s]`, volWwn)
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(0 ,nil , cmdErr)
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(1 ,nil , cmdErr)
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(2 ,[]byte(fmt.Sprintf("%s", inqResult)) , nil)
+			dev, err := bdUtils.DiscoverBySgInq(mpathOutput, expectedWwn)
+			Expect(dev).To(Equal("mpathhg"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(3))
+			_, cmd, _ := fakeExec.ExecuteWithTimeoutArgsForCall(2)
+			Expect(cmd).To(Equal("sg_inq"))
+		})
+
 		It("should not sg_inq none IBM devices like vendor AAA or faulty device ##", func() {
 			volWwn := "6001738cfc9035eb0000000000cea5f6"
 			deviceName := "mpathhe"
@@ -286,7 +324,7 @@ mpathhb (36001738cfc9035eb0000000000cea###) dm-3 ##,##
 			fakeExec.ExecuteWithTimeoutReturns([]byte(""),returnError)
 			_, err := bdUtils.DiscoverBySgInq(mpathOutput, wwn)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(Equal(&block_device_utils.CommandExecuteError{"sg_inq",returnError}))
+			Expect(err).To(Equal(&block_device_utils.VolumeNotFoundError{wwn}))
 		})
 	})
 	Context(".GetWwnByScsiInq", func() {

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -136,7 +136,9 @@ func (b *blockDeviceUtils) DiscoverBySgInq(mpathOutput string, volumeWwn string)
 			mpathFullPath := b.mpathDevFullPath(dev)
 			wwn, err := b.GetWwnByScsiInq(mpathFullPath)
 			if err != nil {
-				return "", b.logger.ErrorRet(err, "failed")
+				// we ignore errors and keep trying other devices.
+				b.logger.Debug(fmt.Sprintf("device [%s] cannot be sg_inq to validate if its related to WWN [%s]. sg_inq error is [%s]. Skip to the next mpath device.",dev,volumeWwn, err))
+				continue
 			}
 			if strings.ToLower(wwn) == strings.ToLower(volumeWwn) {
 				return dev, nil
@@ -195,6 +197,7 @@ func (b *blockDeviceUtils) GetWwnByScsiInq(dev string) (string, error) {
 	}
 	wwnRegex := "(?i)" + `\[0x(.*?)\]`
 	wwnRegexCompiled, err := regexp.Compile(wwnRegex)
+	
 	if err != nil {
 		return "", b.logger.ErrorRet(err, "failed")
 	}

--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -137,7 +137,7 @@ func (b *blockDeviceUtils) DiscoverBySgInq(mpathOutput string, volumeWwn string)
 			wwn, err := b.GetWwnByScsiInq(mpathFullPath)
 			if err != nil {
 				// we ignore errors and keep trying other devices.
-				b.logger.Debug(fmt.Sprintf("device [%s] cannot be sg_inq to validate if its related to WWN [%s]. sg_inq error is [%s]. Skip to the next mpath device.",dev,volumeWwn, err))
+				b.logger.Warning(fmt.Sprintf("device [%s] cannot be sg_inq to validate if its related to WWN [%s]. sg_inq error is [%s]. Skip to the next mpath device.",dev,volumeWwn, err))
 				continue
 			}
 			if strings.ToLower(wwn) == strings.ToLower(volumeWwn) {


### PR DESCRIPTION
if we encounter a bad mpath device we will continue with the scan of the other devices.

(this is based on :https://github.com/IBM/ubiquity/pull/170  + some code review and test fixes changes )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/247)
<!-- Reviewable:end -->
