### PR TITLE
remove mountpoint safely

### DIFF
--- a/fakes/fake_executor.go
+++ b/fakes/fake_executor.go
@@ -215,17 +215,17 @@ type FakeExecutor struct {
 	isSameFileReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	NumberOfFilesInDirStub        func(dir string) (int, error)
-	numberOfFilesInDirMutex       sync.RWMutex
-	numberOfFilesInDirArgsForCall []struct {
+	IsDirEmptyStub        func(dir string) (bool, error)
+	isDirEmptyMutex       sync.RWMutex
+	isDirEmptyArgsForCall []struct {
 		dir string
 	}
-	numberOfFilesInDirReturns struct {
-		result1 int
+	isDirEmptyReturns struct {
+		result1 bool
 		result2 error
 	}
-	numberOfFilesInDirReturnsOnCall map[int]struct {
-		result1 int
+	isDirEmptyReturnsOnCall map[int]struct {
+		result1 bool
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -1078,53 +1078,53 @@ func (fake *FakeExecutor) IsSameFileReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
-func (fake *FakeExecutor) NumberOfFilesInDir(dir string) (int, error) {
-	fake.numberOfFilesInDirMutex.Lock()
-	ret, specificReturn := fake.numberOfFilesInDirReturnsOnCall[len(fake.numberOfFilesInDirArgsForCall)]
-	fake.numberOfFilesInDirArgsForCall = append(fake.numberOfFilesInDirArgsForCall, struct {
+func (fake *FakeExecutor) IsDirEmpty(dir string) (bool, error) {
+	fake.isDirEmptyMutex.Lock()
+	ret, specificReturn := fake.isDirEmptyReturnsOnCall[len(fake.isDirEmptyArgsForCall)]
+	fake.isDirEmptyArgsForCall = append(fake.isDirEmptyArgsForCall, struct {
 		dir string
 	}{dir})
-	fake.recordInvocation("NumberOfFilesInDir", []interface{}{dir})
-	fake.numberOfFilesInDirMutex.Unlock()
-	if fake.NumberOfFilesInDirStub != nil {
-		return fake.NumberOfFilesInDirStub(dir)
+	fake.recordInvocation("IsDirEmpty", []interface{}{dir})
+	fake.isDirEmptyMutex.Unlock()
+	if fake.IsDirEmptyStub != nil {
+		return fake.IsDirEmptyStub(dir)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.numberOfFilesInDirReturns.result1, fake.numberOfFilesInDirReturns.result2
+	return fake.isDirEmptyReturns.result1, fake.isDirEmptyReturns.result2
 }
 
-func (fake *FakeExecutor) NumberOfFilesInDirCallCount() int {
-	fake.numberOfFilesInDirMutex.RLock()
-	defer fake.numberOfFilesInDirMutex.RUnlock()
-	return len(fake.numberOfFilesInDirArgsForCall)
+func (fake *FakeExecutor) IsDirEmptyCallCount() int {
+	fake.isDirEmptyMutex.RLock()
+	defer fake.isDirEmptyMutex.RUnlock()
+	return len(fake.isDirEmptyArgsForCall)
 }
 
-func (fake *FakeExecutor) NumberOfFilesInDirArgsForCall(i int) string {
-	fake.numberOfFilesInDirMutex.RLock()
-	defer fake.numberOfFilesInDirMutex.RUnlock()
-	return fake.numberOfFilesInDirArgsForCall[i].dir
+func (fake *FakeExecutor) IsDirEmptyArgsForCall(i int) string {
+	fake.isDirEmptyMutex.RLock()
+	defer fake.isDirEmptyMutex.RUnlock()
+	return fake.isDirEmptyArgsForCall[i].dir
 }
 
-func (fake *FakeExecutor) NumberOfFilesInDirReturns(result1 int, result2 error) {
-	fake.NumberOfFilesInDirStub = nil
-	fake.numberOfFilesInDirReturns = struct {
-		result1 int
+func (fake *FakeExecutor) IsDirEmptyReturns(result1 bool, result2 error) {
+	fake.IsDirEmptyStub = nil
+	fake.isDirEmptyReturns = struct {
+		result1 bool
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeExecutor) NumberOfFilesInDirReturnsOnCall(i int, result1 int, result2 error) {
-	fake.NumberOfFilesInDirStub = nil
-	if fake.numberOfFilesInDirReturnsOnCall == nil {
-		fake.numberOfFilesInDirReturnsOnCall = make(map[int]struct {
-			result1 int
+func (fake *FakeExecutor) IsDirEmptyReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.IsDirEmptyStub = nil
+	if fake.isDirEmptyReturnsOnCall == nil {
+		fake.isDirEmptyReturnsOnCall = make(map[int]struct {
+			result1 bool
 			result2 error
 		})
 	}
-	fake.numberOfFilesInDirReturnsOnCall[i] = struct {
-		result1 int
+	fake.isDirEmptyReturnsOnCall[i] = struct {
+		result1 bool
 		result2 error
 	}{result1, result2}
 }
@@ -1166,8 +1166,8 @@ func (fake *FakeExecutor) Invocations() map[string][][]interface{} {
 	defer fake.getGlobFilesMutex.RUnlock()
 	fake.isSameFileMutex.RLock()
 	defer fake.isSameFileMutex.RUnlock()
-	fake.numberOfFilesInDirMutex.RLock()
-	defer fake.numberOfFilesInDirMutex.RUnlock()
+	fake.isDirEmptyMutex.RLock()
+	defer fake.isDirEmptyMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/fakes/fake_executor.go
+++ b/fakes/fake_executor.go
@@ -215,6 +215,19 @@ type FakeExecutor struct {
 	isSameFileReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	NumberOfFilesInDirStub        func(dir string) (int, error)
+	numberOfFilesInDirMutex       sync.RWMutex
+	numberOfFilesInDirArgsForCall []struct {
+		dir string
+	}
+	numberOfFilesInDirReturns struct {
+		result1 int
+		result2 error
+	}
+	numberOfFilesInDirReturnsOnCall map[int]struct {
+		result1 int
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -1065,6 +1078,57 @@ func (fake *FakeExecutor) IsSameFileReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
+func (fake *FakeExecutor) NumberOfFilesInDir(dir string) (int, error) {
+	fake.numberOfFilesInDirMutex.Lock()
+	ret, specificReturn := fake.numberOfFilesInDirReturnsOnCall[len(fake.numberOfFilesInDirArgsForCall)]
+	fake.numberOfFilesInDirArgsForCall = append(fake.numberOfFilesInDirArgsForCall, struct {
+		dir string
+	}{dir})
+	fake.recordInvocation("NumberOfFilesInDir", []interface{}{dir})
+	fake.numberOfFilesInDirMutex.Unlock()
+	if fake.NumberOfFilesInDirStub != nil {
+		return fake.NumberOfFilesInDirStub(dir)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.numberOfFilesInDirReturns.result1, fake.numberOfFilesInDirReturns.result2
+}
+
+func (fake *FakeExecutor) NumberOfFilesInDirCallCount() int {
+	fake.numberOfFilesInDirMutex.RLock()
+	defer fake.numberOfFilesInDirMutex.RUnlock()
+	return len(fake.numberOfFilesInDirArgsForCall)
+}
+
+func (fake *FakeExecutor) NumberOfFilesInDirArgsForCall(i int) string {
+	fake.numberOfFilesInDirMutex.RLock()
+	defer fake.numberOfFilesInDirMutex.RUnlock()
+	return fake.numberOfFilesInDirArgsForCall[i].dir
+}
+
+func (fake *FakeExecutor) NumberOfFilesInDirReturns(result1 int, result2 error) {
+	fake.NumberOfFilesInDirStub = nil
+	fake.numberOfFilesInDirReturns = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeExecutor) NumberOfFilesInDirReturnsOnCall(i int, result1 int, result2 error) {
+	fake.NumberOfFilesInDirStub = nil
+	if fake.numberOfFilesInDirReturnsOnCall == nil {
+		fake.numberOfFilesInDirReturnsOnCall = make(map[int]struct {
+			result1 int
+			result2 error
+		})
+	}
+	fake.numberOfFilesInDirReturnsOnCall[i] = struct {
+		result1 int
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeExecutor) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1102,6 +1166,8 @@ func (fake *FakeExecutor) Invocations() map[string][][]interface{} {
 	defer fake.getGlobFilesMutex.RUnlock()
 	fake.isSameFileMutex.RLock()
 	defer fake.isSameFileMutex.RUnlock()
+	fake.numberOfFilesInDirMutex.RLock()
+	defer fake.numberOfFilesInDirMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/remote/mounter/errors.go
+++ b/remote/mounter/errors.go
@@ -27,3 +27,11 @@ type NoMounterForVolumeError struct {
 func (e *NoMounterForVolumeError) Error() string {
 	return fmt.Sprintf("Mounter not found for backend: %s", e.mounter)
 }
+
+type DirecotryIsNotEmptyError struct {
+	Dir string	
+}
+
+func (e *DirecotryIsNotEmptyError) Error() string {
+	return fmt.Sprintf("Directory [%s] is not empty.", e.Dir)
+}

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -111,7 +111,7 @@ func (s *scbeMounter) Unmount(unmountRequest resources.UnmountRequest) error {
         }
 	}
 	
-	numFiles, err1 := s.exec.NumberOfFilesInDir(mountpoint)
+	numFiles, _ := s.exec.NumberOfFilesInDir(mountpoint)
 	s.logger.Info("checking number of files in dir before the umount flow", logs.Args{{"files", numFiles }})
 	
 	if !skipUnmountFlow{

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -123,13 +123,12 @@ func (s *scbeMounter) Unmount(unmountRequest resources.UnmountRequest) error {
 	// TODO move this part to the util
 	if _, err := s.exec.Stat(mountpoint); err == nil {
 		s.logger.Debug("Checking if mountpoint is empty and can be deleted", logs.Args{{"mountpoint", mountpoint}})
-		numFiles, err := s.exec.NumberOfFilesInDir(mountpoint)
-		s.logger.Info("number of files is", logs.Args{{"files", numFiles}})
+		emptyDir, err := s.exec.IsDirEmpty(mountpoint)
 		if err != nil {
 			return s.logger.ErrorRet(err, "Getting number of files failed.", logs.Args{{"mountpoint", mountpoint}})
 		}
-		if numFiles != 0 {
-			return s.logger.ErrorRet(&DirecotryIsNotEmptyError{mountpoint}, "Directory is not empty and cannot be removed.", logs.Args{{"mountpoint", mountpoint}, {"number of files" , numFiles}})
+		if emptyDir != true {
+			return s.logger.ErrorRet(&DirecotryIsNotEmptyError{mountpoint}, "Directory is not empty and cannot be removed.", logs.Args{{"mountpoint", mountpoint}})
 		}
 		
 		if err := s.exec.RemoveAll(mountpoint); err != nil { // TODO its enough to do Remove without All.

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -121,6 +121,7 @@ func (s *scbeMounter) Unmount(unmountRequest resources.UnmountRequest) error {
 	if _, err := s.exec.Stat(mountpoint); err == nil {
 		s.logger.Debug("Checking if mountpoint is empty and can be deleted", logs.Args{{"mountpoint", mountpoint}})
 		numFiles, err := s.exec.NumberOfFilesInDir(mountpoint)
+		s.logger.Info("number of files is", logs.Args{{"files", numFiles}})
 		if err != nil {
 			return s.logger.ErrorRet(err, "Getting number of files failed.", logs.Args{{"mountpoint", mountpoint}})
 		}

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -113,9 +113,6 @@ func (s *scbeMounter) Unmount(unmountRequest resources.UnmountRequest) error {
         }
 	}
 	
-	numFiles, _ := s.exec.NumberOfFilesInDir(mountpoint)
-	s.logger.Info("checking number of files in dir before the umount flow", logs.Args{{"files", numFiles }})
-	
 	if !skipUnmountFlow{
 		if err := s.blockDeviceMounterUtils.UnmountDeviceFlow(devicePath, volumeWWN); err != nil {
 			return s.logger.ErrorRet(err, "UnmountDeviceFlow failed", logs.Args{{"devicePath", devicePath}})

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -110,6 +110,10 @@ func (s *scbeMounter) Unmount(unmountRequest resources.UnmountRequest) error {
 	            return s.logger.ErrorRet(err, "Discover failed", logs.Args{{"volumeWWN", volumeWWN}})
         }
 	}
+	
+	numFiles, err1 := s.exec.NumberOfFilesInDir(mountpoint)
+	s.logger.Info("checking number of files in dir before the umount flow", logs.Args{{"files", numFiles }})
+	
 	if !skipUnmountFlow{
 		if err := s.blockDeviceMounterUtils.UnmountDeviceFlow(devicePath, volumeWWN); err != nil {
 			return s.logger.ErrorRet(err, "UnmountDeviceFlow failed", logs.Args{{"devicePath", devicePath}})

--- a/remote/mounter/scbe_test.go
+++ b/remote/mounter/scbe_test.go
@@ -87,6 +87,29 @@ var _ = Describe("scbe_mounter_test", func() {
 			Expect(fakeExec.StatCallCount()).To(Equal(1))
 			Expect(fakeExec.RemoveAllCallCount()).To(Equal(1))
 		})
+		It("should  fail if mountpoint dir is not empty", func() {
+			fakeExec.NumberOfFilesInDirReturns(1, nil)
+			volumeConfig := make(map[string]interface{})
+			volumeConfig["Wwn"] = "volumewwn"
+			err := scbeMounter.Unmount(resources.UnmountRequest{volumeConfig, resources.RequestContext{}})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(&mounter.DirecotryIsNotEmptyError{fmt.Sprintf("/ubiquity/%s", volumeConfig["Wwn"])}))
+			Expect(fakeBdUtils.UnmountDeviceFlowCallCount()).To(Equal(1))
+			Expect(fakeExec.StatCallCount()).To(Equal(1))
+			Expect(fakeExec.RemoveAllCallCount()).To(Equal(0))
+		})
+		FIt("should  fail if mountpoint dir returns erorr", func() {
+			returnedErr := fmt.Errorf("An error has occured")
+			fakeExec.NumberOfFilesInDirReturns(-1, returnedErr)
+			volumeConfig := make(map[string]interface{})
+			volumeConfig["Wwn"] = "volumewwn"
+			err := scbeMounter.Unmount(resources.UnmountRequest{volumeConfig, resources.RequestContext{}})
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(returnedErr))
+			Expect(fakeBdUtils.UnmountDeviceFlowCallCount()).To(Equal(1))
+			Expect(fakeExec.StatCallCount()).To(Equal(1))
+			Expect(fakeExec.RemoveAllCallCount()).To(Equal(0))
+		})
 	})
 })
 

--- a/utils/executor.go
+++ b/utils/executor.go
@@ -47,7 +47,7 @@ type Executor interface { // basic host dependent functions
 	IsSlink(fInfo os.FileInfo) bool
 	GetGlobFiles(file_pattern string) (matches []string, err error)
 	IsSameFile(file1  os.FileInfo, file2 os.FileInfo) bool
-	NumberOfFilesInDir(dir string) (int, error)
+	IsDirEmpty(dir string) (bool, error)
 	
 }
 
@@ -171,12 +171,12 @@ func (e *executor) IsSameFile(file1 os.FileInfo, file2 os.FileInfo) bool{
 	return os.SameFile(file1, file2)
 }
 
-func (e *executor) NumberOfFilesInDir(dir string) (int, error){
+func (e *executor) IsDirEmpty(dir string) (bool, error){
 	files, err:= ioutil.ReadDir(dir)
 	e.logger.Debug("the files", logs.Args{{"files", files}})
 	if err != nil{
-		return -1, err
+		return false, err
 	}
 	
-	return len(files), nil
+	return len(files) == 0, nil
 }

--- a/utils/executor.go
+++ b/utils/executor.go
@@ -173,6 +173,7 @@ func (e *executor) IsSameFile(file1 os.FileInfo, file2 os.FileInfo) bool{
 
 func (e *executor) NumberOfFilesInDir(dir string) (int, error){
 	files, err:= ioutil.ReadDir(dir)
+	e.logger.Debug("the files", logs.Args{{"files", files}})
 	if err != nil{
 		return -1, err
 	}

--- a/utils/executor.go
+++ b/utils/executor.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"time"
+	"io/ioutil"
 )
 
 //go:generate counterfeiter -o ../fakes/fake_executor.go . Executor
@@ -46,6 +47,7 @@ type Executor interface { // basic host dependent functions
 	IsSlink(fInfo os.FileInfo) bool
 	GetGlobFiles(file_pattern string) (matches []string, err error)
 	IsSameFile(file1  os.FileInfo, file2 os.FileInfo) bool
+	NumberOfFilesInDir(dir string) (int, error)
 	
 }
 
@@ -167,4 +169,13 @@ func (e *executor)	GetGlobFiles(file_pattern string) (matches []string, err erro
 }
 func (e *executor) IsSameFile(file1 os.FileInfo, file2 os.FileInfo) bool{
 	return os.SameFile(file1, file2)
+}
+
+func (e *executor) NumberOfFilesInDir(dir string) (int, error){
+	files, err:= ioutil.ReadDir(dir)
+	if err != nil{
+		return -1, err
+	}
+	
+	return len(files), nil
 }


### PR DESCRIPTION
in this PR we want to check before deleting the /ubiquity/wwn folder if there are any files left there. if there are still files(e.g for some reason the mountpoint directory /ubiquity/wwn had some files before the block device mountpoint on it) - an ERROR will be raised until the folder will be cleaned of files.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/248)
<!-- Reviewable:end -->
