### PR TITLE
Feature/upgrade Alpine3.8, openssl and ca-certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode 
 
 
 FROM alpine:3.8
-RUN apk --no-cache add ca-certificates-20171114-r3 openssl=1.0.2p-r0
+RUN apk --no-cache add ca-certificates=20171114-r3 openssl=1.0.2p-r0
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity/ubiquity .
 COPY --from=0 /go/src/github.com/IBM/ubiquity/LICENSE .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ COPY . .
 RUN CGO_ENABLED=1 GOOS=linux go build -tags netgo -v -a --ldflags '-w -linkmode external -extldflags "-static"' -installsuffix cgo -o ubiquity main.go
 
 
-FROM alpine:3.7
-RUN apk --no-cache add ca-certificates=20171114-r0 openssl=1.0.2o-r1
+FROM alpine:3.8
+RUN apk --no-cache add ca-certificates-20171114-r3 openssl=1.0.2p-r0
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/IBM/ubiquity/ubiquity .
 COPY --from=0 /go/src/github.com/IBM/ubiquity/LICENSE .


### PR DESCRIPTION
1. upgrade ubiqutiy server from Alpine 3.7 to 3.8
2. Due to Alpine upgrade, we should upgrade openssl from 1.0.2o-r1   to  openssl-1.0.2p-r0. (To aligned based on list mentioned [HERE](http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/) )
3. Due to Alpine upgrade, we should upgrafr ca-certificates from 20171114-r0 to 20171114-r3.

Also related to https://github.com/IBM/ubiquity-k8s/pull/217
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/251)
<!-- Reviewable:end -->
