### PR TITLE
Fix/ub 1671 idempotent issues in delete

### DIFF
--- a/local/scbe/datamodel_wrapper.go
+++ b/local/scbe/datamodel_wrapper.go
@@ -98,11 +98,6 @@ func (d *scbeDataModelWrapper) DeleteVolume(name string) error {
 
 	if database.IsDatabaseVolume(name) {
 
-		// sanity
-		if d.dbVolume == nil {
-			return d.logger.ErrorRet(&resources.VolumeNotFoundError{VolName: name}, "failed")
-		}
-
 		// work with memory object
 		d.UpdateDatabaseVolume(nil)
 

--- a/local/scbe/datamodel_wrapper_test.go
+++ b/local/scbe/datamodel_wrapper_test.go
@@ -17,24 +17,24 @@
 package scbe_test
 
 import (
-  . "github.com/onsi/ginkgo"
-  . "github.com/onsi/gomega"
 	"github.com/IBM/ubiquity/database"
 	"github.com/IBM/ubiquity/local/scbe"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("ScbeDataModelWrapper test", func() {
 
 	var (
-		dataModelWrapper   scbe.ScbeDataModelWrapper
-		err                error
-		volumeName         string = "volumeName"
-		volumeWwn          string = "wwn"
-		volumeFsType       string = "volumeFsType"
-		volumeNameDb       string = volumeName + database.VolumeNameSuffix
-		volumeWwnDb        string = volumeWwn + database.VolumeNameSuffix
-		volumeFsTypeDb     string = volumeFsType + database.VolumeNameSuffix
-		scbeVolume         scbe.ScbeVolume
+		dataModelWrapper scbe.ScbeDataModelWrapper
+		err              error
+		volumeName       string = "volumeName"
+		volumeWwn        string = "wwn"
+		volumeFsType     string = "volumeFsType"
+		volumeNameDb     string = volumeName + database.VolumeNameSuffix
+		volumeWwnDb      string = volumeWwn + database.VolumeNameSuffix
+		volumeFsTypeDb   string = volumeFsType + database.VolumeNameSuffix
+		scbeVolume       scbe.ScbeVolume
 	)
 
 	BeforeEach(func() {
@@ -45,57 +45,57 @@ var _ = Describe("ScbeDataModelWrapper test", func() {
 	})
 
 	Context("Database cannot be accessed yet", func() {
-        Context("InsertVolume", func() {
-            It("succeed for db volume", func() {
-                defer database.InitTestError()()
-                err = dataModelWrapper.InsertVolume(volumeNameDb, volumeWwnDb, volumeFsTypeDb)
-                Expect(err).To(Not(HaveOccurred()))
-                scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, true)
-                Expect(err).To(Not(HaveOccurred()))
-            })
-            It("fail for non db volume", func() {
-                defer database.InitTestError()()
-                err = dataModelWrapper.InsertVolume(volumeName, volumeWwn, volumeFsType)
-                Expect(err).To(HaveOccurred())
-                scbeVolume, err = dataModelWrapper.GetVolume(volumeName, true)
-                Expect(err).To(HaveOccurred())
-            })
-        })
-        Context("DeleteVolume", func() {
-            It("succeed for db volume", func() {
-                defer database.InitTestError()()
-                err = dataModelWrapper.InsertVolume(volumeNameDb, volumeWwnDb, volumeFsTypeDb)
-                Expect(err).To(Not(HaveOccurred()))
-                scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, true)
-                Expect(err).To(Not(HaveOccurred()))
-                err = dataModelWrapper.DeleteVolume(volumeNameDb)
-                Expect(err).To(Not(HaveOccurred()))
-                scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, false)
-                Expect(err).To(Not(HaveOccurred()))
-            })
-            It("succeed if db volume does not exist", func() {
+		Context("InsertVolume", func() {
+			It("succeed for db volume", func() {
+				defer database.InitTestError()()
+				err = dataModelWrapper.InsertVolume(volumeNameDb, volumeWwnDb, volumeFsTypeDb)
+				Expect(err).To(Not(HaveOccurred()))
+				scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, true)
+				Expect(err).To(Not(HaveOccurred()))
+			})
+			It("fail for non db volume", func() {
+				defer database.InitTestError()()
+				err = dataModelWrapper.InsertVolume(volumeName, volumeWwn, volumeFsType)
+				Expect(err).To(HaveOccurred())
+				scbeVolume, err = dataModelWrapper.GetVolume(volumeName, true)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("DeleteVolume", func() {
+			It("succeed for db volume", func() {
+				defer database.InitTestError()()
+				err = dataModelWrapper.InsertVolume(volumeNameDb, volumeWwnDb, volumeFsTypeDb)
+				Expect(err).To(Not(HaveOccurred()))
+				scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, true)
+				Expect(err).To(Not(HaveOccurred()))
 				err = dataModelWrapper.DeleteVolume(volumeNameDb)
-                Expect(err).To(Not(HaveOccurred()))
-            })
-        })
-        Context("UpdateDatabaseVolume", func() {
-            It("succeed", func() {
-                defer database.InitTestError()()
-                err = dataModelWrapper.InsertVolume(volumeNameDb, volumeWwnDb, volumeFsTypeDb)
-                Expect(err).To(Not(HaveOccurred()))
-                scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, true)
-                Expect(err).To(Not(HaveOccurred()))
-                err = dataModelWrapper.DeleteVolume(volumeNameDb)
-                Expect(err).To(Not(HaveOccurred()))
-                dataModelWrapper.UpdateDatabaseVolume(&scbeVolume)
-                scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, true)
-                Expect(err).To(Not(HaveOccurred()))
-                dataModelWrapper.UpdateDatabaseVolume(nil)
-                scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, false)
-                Expect(err).To(Not(HaveOccurred()))
-            })
-        })
-    })
+				Expect(err).To(Not(HaveOccurred()))
+				scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, false)
+				Expect(err).To(Not(HaveOccurred()))
+			})
+			It("succeed if db volume does not exist", func() {
+				err = dataModelWrapper.DeleteVolume(volumeNameDb)
+				Expect(err).To(Not(HaveOccurred()))
+			})
+		})
+		Context("UpdateDatabaseVolume", func() {
+			It("succeed", func() {
+				defer database.InitTestError()()
+				err = dataModelWrapper.InsertVolume(volumeNameDb, volumeWwnDb, volumeFsTypeDb)
+				Expect(err).To(Not(HaveOccurred()))
+				scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, true)
+				Expect(err).To(Not(HaveOccurred()))
+				err = dataModelWrapper.DeleteVolume(volumeNameDb)
+				Expect(err).To(Not(HaveOccurred()))
+				dataModelWrapper.UpdateDatabaseVolume(&scbeVolume)
+				scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, true)
+				Expect(err).To(Not(HaveOccurred()))
+				dataModelWrapper.UpdateDatabaseVolume(nil)
+				scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, false)
+				Expect(err).To(Not(HaveOccurred()))
+			})
+		})
+	})
 })
 
 func isEqualScbeVolumes(list1 []scbe.ScbeVolume, list2 []scbe.ScbeVolume) bool {

--- a/local/scbe/datamodel_wrapper_test.go
+++ b/local/scbe/datamodel_wrapper_test.go
@@ -73,6 +73,10 @@ var _ = Describe("ScbeDataModelWrapper test", func() {
                 scbeVolume, err = dataModelWrapper.GetVolume(volumeNameDb, false)
                 Expect(err).To(Not(HaveOccurred()))
             })
+            It("succeed if db volume does not exist", func() {
+				err = dataModelWrapper.DeleteVolume(volumeNameDb)
+                Expect(err).To(Not(HaveOccurred()))
+            })
         })
         Context("UpdateDatabaseVolume", func() {
             It("succeed", func() {

--- a/local/scbe/errors.go
+++ b/local/scbe/errors.go
@@ -208,20 +208,20 @@ func (e *VolumeNotFoundOnArrayError) Error() string {
 }
 
 type BadHttpStatusCodeError struct {
-	httpStatusCode         int
-	httpExpectedStatusCode int
-	httpDataStr            string
-	httpAction             string
-	httpUrl                string
+	HttpStatusCode         int
+	HttpExpectedStatusCode int
+	HttpDataStr            string
+	HttpAction             string
+	HttpUrl                string
 }
 
 func (e *BadHttpStatusCodeError) Error() string {
 	return fmt.Sprintf(
 		ScName+" unexpected HTTP status code. HTTP response detail: 'status code'=[%d], 'expected status code'=[%d], 'data'=[%s], 'action'=[%s], 'url'=[%s].",
-		e.httpStatusCode,
-		e.httpExpectedStatusCode,
-		e.httpDataStr,
-		e.httpAction,
-		e.httpUrl,
+		e.HttpStatusCode,
+		e.HttpExpectedStatusCode,
+		e.HttpDataStr,
+		e.HttpAction,
+		e.HttpUrl,
 	)
 }

--- a/local/scbe/scbe.go
+++ b/local/scbe/scbe.go
@@ -309,7 +309,7 @@ func (s *scbeLocalClient) RemoveVolume(removeVolumeRequest resources.RemoveVolum
 	}
 	
 	// REMOVE THIS!!!
-	return s.logger.ErrorRet(err, "######TRYING TO DO IDEMPOTENT ISSUE")
+	return s.logger.ErrorRet(fmt.Errorf("some error"), "######TRYING TO DO IDEMPOTENT ISSUE")
 
 	if err = s.dataModel.DeleteVolume(removeVolumeRequest.Name); err != nil {
 		return s.logger.ErrorRet(err, "dataModel.DeleteVolume failed")

--- a/local/scbe/scbe.go
+++ b/local/scbe/scbe.go
@@ -307,6 +307,9 @@ func (s *scbeLocalClient) RemoveVolume(removeVolumeRequest resources.RemoveVolum
 	if err = scbeRestClient.DeleteVolume(existingVolume.WWN); err != nil {
 		return s.logger.ErrorRet(err, "scbeRestClient.DeleteVolume failed")
 	}
+	
+	// REMOVE THIS!!!
+	return s.logger.ErrorRet(err, "######TRYING TO DO IDEMPOTENT ISSUE")
 
 	if err = s.dataModel.DeleteVolume(removeVolumeRequest.Name); err != nil {
 		return s.logger.ErrorRet(err, "dataModel.DeleteVolume failed")

--- a/local/scbe/scbe.go
+++ b/local/scbe/scbe.go
@@ -291,6 +291,7 @@ func (s *scbeLocalClient) RemoveVolume(removeVolumeRequest resources.RemoveVolum
 	}
 
 	existingVolume, err := s.dataModel.GetVolume(removeVolumeRequest.Name, true)
+	// check errror is volume not found then return nil
 	if err != nil {
 		return s.logger.ErrorRet(err, "dataModel.GetVolume failed")
 	}
@@ -302,11 +303,13 @@ func (s *scbeLocalClient) RemoveVolume(removeVolumeRequest resources.RemoveVolum
 
 	if hostAttach != EmptyHost {
 		return s.logger.ErrorRet(&CannotDeleteVolWhichAttachedToHostError{removeVolumeRequest.Name, hostAttach}, "failed")
-	}
+	} 
 
-	if err = scbeRestClient.DeleteVolume(existingVolume.WWN); err != nil {
+	err = scbeRestClient.DeleteVolume(existingVolume.WWN); if err != nil {
 		return s.logger.ErrorRet(err, "scbeRestClient.DeleteVolume failed")
 	}
+	// check error return code if its 404 then continue with idempotent comment 
+	
 	
 	// REMOVE THIS!!!
 	return s.logger.ErrorRet(fmt.Errorf("some error"), "######TRYING TO DO IDEMPOTENT ISSUE")
@@ -314,6 +317,7 @@ func (s *scbeLocalClient) RemoveVolume(removeVolumeRequest resources.RemoveVolum
 	if err = s.dataModel.DeleteVolume(removeVolumeRequest.Name); err != nil {
 		return s.logger.ErrorRet(err, "dataModel.DeleteVolume failed")
 	}
+	// check if error is volume not found. if so then return nil. 
 
 	return nil
 }

--- a/local/scbe/scbe.go
+++ b/local/scbe/scbe.go
@@ -314,9 +314,11 @@ func (s *scbeLocalClient) RemoveVolume(removeVolumeRequest resources.RemoveVolum
 
 	err = scbeRestClient.DeleteVolume(existingVolume.WWN); 
 	
-	s.logger.Info(fmt.Sprintf("####err : %s, type : %s", err, reflect.TypeOf(err))
+	s.logger.Info(fmt.Sprintf("####err : %s, type : %s", err, reflect.TypeOf(err)))
 	if err != nil {
-		if strings.Contains(err.Error(), resources.VolumeNotFoundError)
+		if strings.Contains(err.Error(), resources.VolumeNotFoundErrorMsg){
+			s.logger.Info("HERERER")
+		}
 		return s.logger.ErrorRet(err, "scbeRestClient.DeleteVolume failed")
 	}
 	

--- a/local/scbe/scbe.go
+++ b/local/scbe/scbe.go
@@ -320,7 +320,7 @@ func (s *scbeLocalClient) RemoveVolume(removeVolumeRequest resources.RemoveVolum
 	if err != nil {
 		switch err.(type) {
 			case *BadHttpStatusCodeError:
-				if err.httpStatusCode == 404{
+				if err.(*BadHttpStatusCodeError).httpStatusCode == 404{
 					s.logger.Warning("Idempotent issue encountered: volume was not found in DB during remove request.",logs.Args{{"volume", removeVolumeRequest.Name}} )
 					return nil	
 					

--- a/local/scbe/scbe_rest_client.go
+++ b/local/scbe/scbe_rest_client.go
@@ -216,7 +216,8 @@ func (s *scbeRestClient) GetVolMapping(wwn string) (string, error) {
 		s.logger.Debug("", logs.Args{{"hostResponse", hostResponse}})
 		host = hostResponse.Name
 	}
-
+	
+	// remove this comment if len(mappings == 0 )
 	s.logger.Debug("volume is mapped", logs.Args{{"host", host}})
 	return host, nil
 }

--- a/local/scbe/scbe_rest_client.go
+++ b/local/scbe/scbe_rest_client.go
@@ -216,9 +216,12 @@ func (s *scbeRestClient) GetVolMapping(wwn string) (string, error) {
 		s.logger.Debug("", logs.Args{{"hostResponse", hostResponse}})
 		host = hostResponse.Name
 	}
-	
-	// remove this comment if len(mappings == 0 )
-	s.logger.Debug("volume is mapped", logs.Args{{"host", host}})
+
+	if len(mappings) != 0 {
+		s.logger.Debug("volume is mapped", logs.Args{{"volume", wwn}, {"host", host}})
+	} else {
+		s.logger.Debug("volume is not mapped", logs.Args{{"volume", wwn}})
+	}
 	return host, nil
 }
 

--- a/local/scbe/simple_rest_client.go
+++ b/local/scbe/simple_rest_client.go
@@ -170,11 +170,11 @@ func (s *simpleRestClient) genericActionInternal(actionName string, resource_url
 	s.logger.Debug(actionName+" "+url, logs.Args{{"data", httpDataStr}})
 	if response.StatusCode != exitStatus {
 		return s.logger.ErrorRet(&BadHttpStatusCodeError{
-			httpStatusCode:         response.StatusCode,
-			httpExpectedStatusCode: exitStatus,
-			httpDataStr:            httpDataStr,
-			httpAction:             actionName,
-			httpUrl:                url,
+			HttpStatusCode:         response.StatusCode,
+			HttpExpectedStatusCode: exitStatus,
+			HttpDataStr:            httpDataStr,
+			HttpAction:             actionName,
+			HttpUrl:                url,
 		}, "failed")
 	}
 

--- a/web_server/storage_api_handler.go
+++ b/web_server/storage_api_handler.go
@@ -129,9 +129,15 @@ func (h *StorageApiHandler) RemoveVolume() http.HandlerFunc {
 
 		backend, err := h.getBackend(removeVolumeRequest.Name)
 		if err != nil {
-			h.logger.Error("error-backend-not-found-for-volume", logs.Args{{"name", removeVolumeRequest.Name}})
-			utils.WriteResponse(w, http.StatusNotFound, &resources.GenericResponse{Err: err.Error()})
-			return
+			switch err.(type) {
+				case *resources.VolumeNotFoundError:
+					b.logger.Warning("Idempotent issue encountered : volume does not exist in remove command.", logs.Args{{"volume", removeVolumeRequest.Name}})
+					return utils.WriteResponse(w, http.StatusOK, nil)
+				default:
+					h.logger.Error("error-backend-not-found-for-volume", logs.Args{{"name", removeVolumeRequest.Name}})
+					utils.WriteResponse(w, http.StatusNotFound, &resources.GenericResponse{Err: err.Error()})
+					return
+			}
 		}
 
 		h.locker.WriteLock(removeVolumeRequest.Name)

--- a/web_server/storage_api_handler.go
+++ b/web_server/storage_api_handler.go
@@ -131,8 +131,9 @@ func (h *StorageApiHandler) RemoveVolume() http.HandlerFunc {
 		if err != nil {
 			switch err.(type) {
 				case *resources.VolumeNotFoundError:
-					b.logger.Warning("Idempotent issue encountered : volume does not exist in remove command.", logs.Args{{"volume", removeVolumeRequest.Name}})
-					return utils.WriteResponse(w, http.StatusOK, nil)
+					h.logger.Warning("Idempotent issue encountered : volume does not exist in remove command.", logs.Args{{"volume", removeVolumeRequest.Name}})
+					utils.WriteResponse(w, http.StatusOK, nil)
+					return
 				default:
 					h.logger.Error("error-backend-not-found-for-volume", logs.Args{{"name", removeVolumeRequest.Name}})
 					utils.WriteResponse(w, http.StatusNotFound, &resources.GenericResponse{Err: err.Error()})


### PR DESCRIPTION
in this PR the idempotent issues in the delete request are fixed.
the issues are as follows: (in delete volume function)

- in get Back-end in the storage_api_handler delete function - if volume does not exist then return nil.
- in get volume: if volume does not exist then return success
- in vol delete from XIV : if an 404 error is returned from SC then continue with the flow. (to delete from ubiquity DB)
- in delete volume from DB (for the case where we have a non-db volume) if a volume not found error is returned then return success.

comment : we are working under the assumption that if a volume is removed from the DB then it is definitely removed from the storage since the removal from the DB is the latter operation. 