### PR TITLE
rest usage optimazation

### DIFF
--- a/local/spectrumscale/connectors/rest_v2.go
+++ b/local/spectrumscale/connectors/rest_v2.go
@@ -96,7 +96,7 @@ func (s *spectrumRestV2) waitForJobCompletion(statusCode int, jobID uint64) erro
     defer s.logger.Trace(logs.DEBUG)()
 
 	if s.checkAsynchronousJob(statusCode) {
-		jobURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/jobs?filter=jobId=%d&fields=:all:", jobID))
+		jobURL := utils.FormatURL(s.endpoint, fmt.Sprintf("scalemgmt/v2/jobs/%d?fields=:all:", jobID))
 		s.logger.Debug("Job URL: ", logs.Args{{"jobUrl", jobURL}})
 		err := s.AsyncJobCompletion(jobURL)
 		if err != nil {
@@ -548,7 +548,7 @@ func (s *spectrumRestV2) ListFilesetQuota(filesystemName string, filesetName str
 	if len(listQuotaResponse.Quotas) > 0 {
 		return fmt.Sprintf("%dK", listQuotaResponse.Quotas[0].BlockQuota), nil
 	} else {
-		return "", fmt.Errorf("Unable to fetch quota information %v. Please refer Ubiquity server logs for more details", filesystemName)
+		return "", fmt.Errorf("Unable to fetch quota information for fileset %v in filesystem %v. Please refer Ubiquity server logs for more details", filesetName, filesystemName)
 	}
 }
 

--- a/local/spectrumscale/connectors/rest_v2_test.go
+++ b/local/spectrumscale/connectors/rest_v2_test.go
@@ -227,7 +227,7 @@ var _ = Describe("spectrumRestV2", func() {
 			createFilesetResp.Jobs = make([]connectors.Job, 1)
 			createFilesetResp.Jobs[0].JobID = 1234
 			registerurl = fakeurl + "/scalemgmt/v2/filesystems/" + filesystem + "/filesets"
-			joburl = fakeurl + "/scalemgmt/v2/jobs?filter=jobId=1234&fields=:all:"
+			joburl = fakeurl + "/scalemgmt/v2/jobs/1234"
 
 		})
 		It("Should pass while creating a fileset", func() {
@@ -352,7 +352,7 @@ var _ = Describe("spectrumRestV2", func() {
 			deleteFilesetResp.Jobs[0].JobID = 1234
 			registerurl = fakeurl + "/scalemgmt/v2/filesystems/" + filesystem + "/filesets/" + fileset
 
-			joburl = fakeurl + "/scalemgmt/v2/jobs?filter=jobId=1234&fields=:all:"
+			joburl = fakeurl + "/scalemgmt/v2/jobs/1234?fields=:all:"
 
 		})
 		It("Should pass while deleting a fileset", func() {
@@ -456,7 +456,7 @@ var _ = Describe("spectrumRestV2", func() {
 			linkFilesetResp.Jobs = make([]connectors.Job, 1)
 			linkFilesetResp.Jobs[0].JobID = 1234
 			registerurl = fakeurl + "/scalemgmt/v2/filesystems/" + filesystem + "/filesets/" + fileset + "/link"
-			joburl = fakeurl + "/scalemgmt/v2/jobs?filter=jobId=1234&fields=:all:"
+			joburl = fakeurl + "/scalemgmt/v2/jobs/1234?fields=:all:"
 			registerFSurl = fakeurl + "/scalemgmt/v2/filesystems/" + filesystem
 			getfilesysResp = connectors.GetFilesystemResponse_v2{}
 			getfilesysResp.FileSystems = make([]connectors.FileSystem_v2, 1)
@@ -595,7 +595,7 @@ var _ = Describe("spectrumRestV2", func() {
 			unlinkFilesetResp.Jobs = make([]connectors.Job, 1)
 			unlinkFilesetResp.Jobs[0].JobID = 1234
 			registerurl = fakeurl + "/scalemgmt/v2/filesystems/" + filesystem + "/filesets/" + fileset + "/link?force=True"
-			joburl = fakeurl + "/scalemgmt/v2/jobs?filter=jobId=1234&fields=:all:"
+			joburl = fakeurl + "/scalemgmt/v2/jobs/1234?fields=:all:"
 
 		})
 		It("should pass while deleting a fileset", func() {
@@ -906,7 +906,7 @@ var _ = Describe("spectrumRestV2", func() {
 			setFilesetResp.Jobs = make([]connectors.Job, 1)
 			setFilesetResp.Jobs[0].JobID = 1234
 			registerurl = fakeurl + "/scalemgmt/v2/filesystems/" + filesystem + "/quotas"
-			joburl = fakeurl + "/scalemgmt/v2/jobs?filter=jobId=1234&fields=:all:"
+			joburl = fakeurl + "/scalemgmt/v2/jobs/1234?fields=:all:"
 
 		})
 		It("Should pass while creating a fileset", func() {

--- a/local/spectrumscale/errors.go
+++ b/local/spectrumscale/errors.go
@@ -69,3 +69,25 @@ type SpectrumScaleFileSystemMountError struct {
 func (e *SpectrumScaleFileSystemMountError) Error() string {
 	return fmt.Sprintf("Failed to check if Filesystem [%s] is mounted", e.Filesystem)
 }
+
+type SpectrumScaleFileSetLinkError struct {
+	Filesystem string
+	Fileset    string
+}
+
+func (e * SpectrumScaleFileSetLinkError) Error() string {
+	return fmt.Sprintf("Failed to check Fileset [%s] Link Status, present in Filesystem [%s]", e.Fileset, e.Filesystem)
+}
+
+type SpectrumScaleFileSetNotLinkError struct {
+	Filesystem string
+	Fileset    string
+}
+
+func (e * SpectrumScaleFileSetNotLinkError) Error() string {
+	return fmt.Sprintf("Fileset [%s] present in Filesystem [%s] is not Linked", e.Fileset, e.Filesystem)
+}
+
+
+
+


### PR DESCRIPTION
- Using reset JobID in the rest call instead of using in filter.
- Updated testcases.
- Handled existing fileset functionality differently using isPreexisting flag in storageClass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/270)
<!-- Reviewable:end -->
