### PR TITLE
spectrumscale fixing Paging variable type

### DIFF
--- a/local/spectrumscale/connectors/resources.go
+++ b/local/spectrumscale/connectors/resources.go
@@ -479,7 +479,7 @@ type FilesetConfig_v2 struct {
 type GetQuotaResponse_v2 struct {
 	Quotas []Quota_v2 `json:"quotas,omitempty"`
 	Status Status     `json:"status,omitempty"`
-	Paging string     `json:"paging,omitempty"`
+	Paging Pages      `json:"paging,omitempty"`
 }
 
 type Quota_v2 struct {


### PR DESCRIPTION
Fixing the paging variable type to Pages instead of string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/273)
<!-- Reviewable:end -->
