### PR TITLE
Fix/ub-1722 soft link issue on uncleared node

### DIFF
--- a/fakes/fake_executor.go
+++ b/fakes/fake_executor.go
@@ -228,6 +228,17 @@ type FakeExecutor struct {
 		result1 bool
 		result2 error
 	}
+	GetDeviceForFileStatStub        func(os.FileInfo) uint64
+	getDeviceForFileStatMutex       sync.RWMutex
+	getDeviceForFileStatArgsForCall []struct {
+		arg1 os.FileInfo
+	}
+	getDeviceForFileStatReturns struct {
+		result1 uint64
+	}
+	getDeviceForFileStatReturnsOnCall map[int]struct {
+		result1 uint64
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -1129,6 +1140,54 @@ func (fake *FakeExecutor) IsDirEmptyReturnsOnCall(i int, result1 bool, result2 e
 	}{result1, result2}
 }
 
+func (fake *FakeExecutor) GetDeviceForFileStat(arg1 os.FileInfo) uint64 {
+	fake.getDeviceForFileStatMutex.Lock()
+	ret, specificReturn := fake.getDeviceForFileStatReturnsOnCall[len(fake.getDeviceForFileStatArgsForCall)]
+	fake.getDeviceForFileStatArgsForCall = append(fake.getDeviceForFileStatArgsForCall, struct {
+		arg1 os.FileInfo
+	}{arg1})
+	fake.recordInvocation("GetDeviceForFileStat", []interface{}{arg1})
+	fake.getDeviceForFileStatMutex.Unlock()
+	if fake.GetDeviceForFileStatStub != nil {
+		return fake.GetDeviceForFileStatStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.getDeviceForFileStatReturns.result1
+}
+
+func (fake *FakeExecutor) GetDeviceForFileStatCallCount() int {
+	fake.getDeviceForFileStatMutex.RLock()
+	defer fake.getDeviceForFileStatMutex.RUnlock()
+	return len(fake.getDeviceForFileStatArgsForCall)
+}
+
+func (fake *FakeExecutor) GetDeviceForFileStatArgsForCall(i int) os.FileInfo {
+	fake.getDeviceForFileStatMutex.RLock()
+	defer fake.getDeviceForFileStatMutex.RUnlock()
+	return fake.getDeviceForFileStatArgsForCall[i].arg1
+}
+
+func (fake *FakeExecutor) GetDeviceForFileStatReturns(result1 uint64) {
+	fake.GetDeviceForFileStatStub = nil
+	fake.getDeviceForFileStatReturns = struct {
+		result1 uint64
+	}{result1}
+}
+
+func (fake *FakeExecutor) GetDeviceForFileStatReturnsOnCall(i int, result1 uint64) {
+	fake.GetDeviceForFileStatStub = nil
+	if fake.getDeviceForFileStatReturnsOnCall == nil {
+		fake.getDeviceForFileStatReturnsOnCall = make(map[int]struct {
+			result1 uint64
+		})
+	}
+	fake.getDeviceForFileStatReturnsOnCall[i] = struct {
+		result1 uint64
+	}{result1}
+}
+
 func (fake *FakeExecutor) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1168,6 +1227,8 @@ func (fake *FakeExecutor) Invocations() map[string][][]interface{} {
 	defer fake.isSameFileMutex.RUnlock()
 	fake.isDirEmptyMutex.RLock()
 	defer fake.isDirEmptyMutex.RUnlock()
+	fake.getDeviceForFileStatMutex.RLock()
+	defer fake.getDeviceForFileStatMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/utils/executor.go
+++ b/utils/executor.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"time"
+	"syscall"
 
 	"github.com/IBM/ubiquity/utils/logs"
 )

--- a/utils/executor.go
+++ b/utils/executor.go
@@ -49,6 +49,8 @@ type Executor interface { // basic host dependent functions
 	GetGlobFiles(file_pattern string) (matches []string, err error)
 	IsSameFile(file1 os.FileInfo, file2 os.FileInfo) bool
 	IsDirEmpty(dir string) (bool, error)
+	GetDeviceForFileStat(os.FileInfo) uint64
+
 }
 
 type executor struct {
@@ -179,4 +181,8 @@ func (e *executor) IsDirEmpty(dir string) (bool, error) {
 	}
 
 	return len(files) == 0, nil
+}
+
+func (e *executor) GetDeviceForFileStat(fileStat os.FileInfo) uint64{
+	return fileStat.Sys().(*syscall.Stat_t).Dev
 }


### PR DESCRIPTION
in this PR the issue that is solved is the following:
as part of the mount there is a check made to see if there are any solf links pointing to the desired mount point ( to /ubiquity/WWN) -this is needed in order to not allow 2 pods to be attached to the same PVC. 
an issue may accur when one of those soft links  is not actually active (for example of a pod  moving to another node in the cluster and back to the original one due to shutdowns) - this is what this PR solves.
beside checking if any soft links exists - a check is made to see if the mount point is mounted. if it is then this is a valid solf link and the current mount should fail. otherwise the current mount can continue un-interrupted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/274)
<!-- Reviewable:end -->
