### PR TITLE
UB-1622 provisioner long time for start in the installation phase

### DIFF
--- a/remote/client.go
+++ b/remote/client.go
@@ -51,12 +51,12 @@ func (s *remoteClient) Activate(activateRequest resources.ActivateRequest) error
 
 	clientWithShortTimeout := new(http.Client)
 	*clientWithShortTimeout = *s.httpClient
-	clientWithShortTimeout.Timeout = time.Second * 2
+	clientWithShortTimeout.Timeout = time.Second * 5
 
 	var err error
 	var response *http.Response
-	// retry 30 times in case the ubiquity server is not ready yet
-	for i := 30; i > 0; i-- {
+	// retry 15 times in case the ubiquity server is not ready yet
+	for i := 15; i > 0; i-- {
 		response, err = utils.HttpExecute(clientWithShortTimeout, "POST", activateURL, activateRequest, activateRequest.Context)
 		if err == nil {
 			break

--- a/remote/client_init.go
+++ b/remote/client_init.go
@@ -20,14 +20,16 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/IBM/ubiquity/resources"
-	"github.com/IBM/ubiquity/utils"
-	"github.com/IBM/ubiquity/utils/logs"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"strings"
+	"time"
+
+	"github.com/IBM/ubiquity/resources"
+	"github.com/IBM/ubiquity/utils"
+	"github.com/IBM/ubiquity/utils/logs"
 )
 
 const KeyUseSsl = "UBIQUITY_PLUGIN_USE_SSL"
@@ -66,7 +68,9 @@ func (s *remoteClient) initialize() error {
 
 	protocol := s.getProtocol()
 	s.storageApiURL = fmt.Sprintf(storageAPIURL, protocol, s.config.UbiquityServer.Address, s.config.UbiquityServer.Port)
-	s.httpClient = &http.Client{}
+	s.httpClient = &http.Client{
+		Timeout: time.Second * 10,
+	}
 	verifyFileCA := os.Getenv(KeyVerifyCA)
 	sslMode := strings.ToLower(os.Getenv(resources.KeySslMode))
 	if sslMode == "" {

--- a/remote/client_init.go
+++ b/remote/client_init.go
@@ -69,7 +69,7 @@ func (s *remoteClient) initialize() error {
 	protocol := s.getProtocol()
 	s.storageApiURL = fmt.Sprintf(storageAPIURL, protocol, s.config.UbiquityServer.Address, s.config.UbiquityServer.Port)
 	s.httpClient = &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: time.Second * 30,
 	}
 	verifyFileCA := os.Getenv(KeyVerifyCA)
 	sslMode := strings.ToLower(os.Getenv(resources.KeySslMode))


### PR DESCRIPTION
helm install takes ~3.5 mins, while provisioner activation takes ~2 mins. The root cause is that the default timeout interval for a http request is very long. This PR:
1. set a short timeout for every request (10 seconds)
2. set a shorter timeout for activation (2 seconds) and retry 30 times if it fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/291)
<!-- Reviewable:end -->
