### PR TITLE
UB-1857: chagne cluster id to be an integer instead of string

### DIFF
--- a/local/scbe/resources.go
+++ b/local/scbe/resources.go
@@ -226,7 +226,7 @@ type ScbeResponseHost struct {
 	Array          string `json:"array"`
 	HostId         string `json:"host_id"`
 	Name           string `json:"name"`
-	StorageCluster string `json:"storage_cluster"`
+	StorageCluster int `json:"storage_cluster"`
 	PhysicalHost   int    `json:"physical_host"`
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/292)
<!-- Reviewable:end -->
