### PR TITLE
UB-1814 : Set PV mountpoint chmod to 775

### DIFF
--- a/remote/mounter/block_device_utils/block_device_utils_test.go
+++ b/remote/mounter/block_device_utils/block_device_utils_test.go
@@ -615,10 +615,14 @@ mpathhb (36001738cfc9035eb0000000000cea###) dm-3 ##,##
 			mpoint := "mpoint"
 			err = bdUtils.MountFs(mpath, mpoint)
 			Expect(err).To(Not(HaveOccurred()))
-			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(1))
+			Expect(fakeExec.ExecuteWithTimeoutCallCount()).To(Equal(2))
 			_, cmd, args := fakeExec.ExecuteWithTimeoutArgsForCall(0)
 			Expect(cmd).To(Equal("mount"))
 			Expect(args).To(Equal([]string{mpath, mpoint}))
+
+			_, cmd, args = fakeExec.ExecuteWithTimeoutArgsForCall(1)
+			Expect(cmd).To(Equal("chmod"))
+			Expect(args).To(Equal([]string{"775", mpoint}))
 		})
 		It("MountFs fails if mount command missing", func() {
 			mpath := "mpath"
@@ -632,6 +636,15 @@ mpathhb (36001738cfc9035eb0000000000cea###) dm-3 ##,##
 			mpath := "mpath"
 			mpoint := "mpoint"
 			fakeExec.ExecuteWithTimeoutReturns([]byte{}, cmdErr)
+			err = bdUtils.MountFs(mpath, mpoint)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))
+		})
+		It("MountFs fails if chmod command fails", func() {
+			mpath := "mpath"
+			mpoint := "mpoint"
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(0, []byte{}, nil)
+			fakeExec.ExecuteWithTimeoutReturnsOnCall(1, []byte{}, cmdErr)
 			err = bdUtils.MountFs(mpath, mpoint)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(MatchRegexp(cmdErr.Error()))

--- a/remote/mounter/block_device_utils/fs.go
+++ b/remote/mounter/block_device_utils/fs.go
@@ -32,6 +32,7 @@ const (
 	TimeoutMilisecondMountCmdIsDeviceMounted = 20 * 1000     // max to wait for mount command
 	TimeoutMilisecondMountCmdMountFs         = 120 * 1000    // max to wait for mounting device
 	TimeoutMilisecondUmountCmdUmountFs       = 30 * 1000	// max wait timeout for umount command
+	TimeoutMilisecondChmodCmd                = 3 * 1000
 )
 
 func (b *blockDeviceUtils) CheckFs(mpath string) (bool, error) {
@@ -73,6 +74,8 @@ func (b *blockDeviceUtils) MakeFs(mpath string, fsType string) error {
 func (b *blockDeviceUtils) MountFs(mpath string, mpoint string) error {
 	defer b.logger.Trace(logs.DEBUG)()
 	mountCmd := "mount"
+	chmodCmd := "chmod"
+
 	if err := b.exec.IsExecutable(mountCmd); err != nil {
 		return b.logger.ErrorRet(&commandNotFoundError{mountCmd, err}, "failed")
 	}
@@ -80,6 +83,13 @@ func (b *blockDeviceUtils) MountFs(mpath string, mpoint string) error {
 	if _, err := b.exec.ExecuteWithTimeout(TimeoutMilisecondMountCmdMountFs, mountCmd, args); err != nil {
 		return b.logger.ErrorRet(&CommandExecuteError{mountCmd, err}, "failed")
 	}
+
+	// Set explicitly the PV mountpoint permission to 775
+	args = []string{"775", mpoint}
+	if _, err := b.exec.ExecuteWithTimeout(TimeoutMilisecondChmodCmd, chmodCmd, args); err != nil {
+		return b.logger.ErrorRet(&CommandExecuteError{chmodCmd, err}, "failed")
+	}
+
 	b.logger.Info("mounted", logs.Args{{"mpoint", mpoint}})
 	return nil
 }


### PR DESCRIPTION
Flex mount the /ubiquity/<WWN> without any special chmod setting, so it takes the system umask.
To make it explicitly flex will chmod 775 /ubiquity/<WWN> after the mount operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/295)
<!-- Reviewable:end -->
