### PR TITLE
change LunNumber from float64 to int

### DIFF
--- a/remote/mounter/block_device_mounter_utils/block_device_utils_mounter_test.go
+++ b/remote/mounter/block_device_mounter_utils/block_device_utils_mounter_test.go
@@ -37,7 +37,7 @@ var _ = Describe("block_device_mounter_utils_test", func() {
 		err                     error
 		callErr                 error = errors.New("error")
 	)
-	volumeMountProperties := &resources.VolumeMountProperties{WWN: "wwn", LunNumber: float64(1)}
+	volumeMountProperties := &resources.VolumeMountProperties{WWN: "wwn", LunNumber: 1}
 
 	BeforeEach(func() {
 		fakeBlockDeviceUtils = new(fakes.FakeBlockDeviceUtils)

--- a/remote/mounter/block_device_utils/block_device_utils_test.go
+++ b/remote/mounter/block_device_utils/block_device_utils_test.go
@@ -44,7 +44,7 @@ var _ = Describe("block_device_utils_test", func() {
 		err             error
 		cmdErr          error = errors.New("command error")
 	)
-	volumeMountProperties := &resources.VolumeMountProperties{WWN: "wwn", LunNumber: float64(1)}
+	volumeMountProperties := &resources.VolumeMountProperties{WWN: "wwn", LunNumber: 1}
 
 	BeforeEach(func() {
 		fakeExec = new(fakes.FakeExecutor)

--- a/remote/mounter/initiator/connectors/fibre_channel_test.go
+++ b/remote/mounter/initiator/connectors/fibre_channel_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Test Fibre Channel Connector", func() {
 		fakeInitiator *fakeinitiator.FakeInitiator
 		fcConnector   initiator.Connector
 	)
-	volumeMountProperties := &resources.VolumeMountProperties{WWN: fakeWwn, LunNumber: float64(1)}
+	volumeMountProperties := &resources.VolumeMountProperties{WWN: fakeWwn, LunNumber: 1}
 
 	BeforeEach(func() {
 		fakeExec = new(fakes.FakeExecutor)

--- a/remote/mounter/initiator/linuxfc.go
+++ b/remote/mounter/initiator/linuxfc.go
@@ -53,11 +53,10 @@ func (lfc *linuxFibreChannel) hasFCSupport() bool {
 // may be '-' wildcards if unable to determine them.
 func (lfc *linuxFibreChannel) getHBAChannelScsiTarget(volumeMountProperties *resources.VolumeMountProperties) string {
 	//TODO: get channel and target
-	if volumeMountProperties.LunNumber == float64(-1) {
+	if volumeMountProperties.LunNumber == -1 {
 		return "- - -"
 	}
-	// use %g to print a float64 to int
-	return fmt.Sprintf("- - %g", volumeMountProperties.LunNumber)
+	return fmt.Sprintf("- - %d", volumeMountProperties.LunNumber)
 }
 
 // GetHBAs return all the FC HBAs in the system

--- a/remote/mounter/initiator/linuxfc_test.go
+++ b/remote/mounter/initiator/linuxfc_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Test FC Initiator", func() {
 		realSysBlockPath string
 		cmdErr           error = errors.New("command error")
 	)
-	volumeMountProperties := &resources.VolumeMountProperties{WWN: "wwn", LunNumber: float64(1)}
+	volumeMountProperties := &resources.VolumeMountProperties{WWN: "wwn", LunNumber: 1}
 
 	BeforeEach(func() {
 		err := os.MkdirAll(FAKE_FC_HOST_SYSFS_PATH, os.ModePerm)
@@ -187,7 +187,7 @@ var _ = Describe("Test FC Initiator", func() {
 				Ω(err).ShouldNot(HaveOccurred())
 				data, err := ioutil.ReadFile(scanFile)
 				Ω(err).ShouldNot(HaveOccurred())
-				Expect(string(data)).To(Equal(fmt.Sprintf("- - %g", volumeMountProperties.LunNumber)))
+				Expect(string(data)).To(Equal(fmt.Sprintf("- - %d", volumeMountProperties.LunNumber)))
 			})
 
 			It("should write '1' to the hba lip file", func() {

--- a/remote/mounter/scbe.go
+++ b/remote/mounter/scbe.go
@@ -53,9 +53,13 @@ func NewScbeMounterWithExecuter(blockDeviceMounterUtils block_device_mounter_uti
 func (s *scbeMounter) prepareVolumeMountProperties(vcGetter resources.VolumeConfigGetter) *resources.VolumeMountProperties {
 	volumeConfig := vcGetter.GetVolumeConfig()
 	volumeWWN := volumeConfig["Wwn"].(string)
-	volumeLunNumber := float64(-1)
+	volumeLunNumber := -1
 	if volumeLunNumberInterface, exists := volumeConfig[resources.ScbeKeyVolAttachLunNumToHost]; exists {
-		volumeLunNumber = volumeLunNumberInterface.(float64)
+
+		// LunNumber is int, but after json.Marshal and json.UNmarshal it will become float64.
+		// see https://stackoverflow.com/questions/39152481/unmarshaling-a-json-integer-to-an-empty-interface-results-in-wrong-type-assertio
+		// but LunNumber should be int, so convert it here.
+		volumeLunNumber = int(volumeLunNumberInterface.(float64))
 	}
 	return &resources.VolumeMountProperties{WWN: volumeWWN, LunNumber: volumeLunNumber}
 }

--- a/remote/mounter/scbe_test.go
+++ b/remote/mounter/scbe_test.go
@@ -40,7 +40,7 @@ var _ = Describe("scbe_mounter_test", func() {
 			"LogicalCapacity": fakeLogicalCapacity, "LunNumber": float64(1), "PoolName": "pool", "StorageName": "IBM.2706", "fstype": "ext4"}}
 		mountRequestForDS8kLun2 = resources.MountRequest{Mountpoint: "test_mountpointDS8k", VolumeConfig: map[string]interface{}{"Name": "u_vol", "PhysicalCapacity": fakePhysicalCapacity,
 			"Profile": fakeProfile, "UsedCapacity": fakeUsedCapacity, "Wwn": "wwn", "attach-to": "node1",
-			"LogicalCapacity": fakeLogicalCapacity, "LunNumber": float64(1), "PoolName": "pool", "StorageName": "IBM.2107", "fstype": "ext4"}}
+			"LogicalCapacity": fakeLogicalCapacity, "LunNumber": float64(1074741264), "PoolName": "pool", "StorageName": "IBM.2107", "fstype": "ext4"}}
 		mountRequestForDS8kLun3 = resources.MountRequest{Mountpoint: "test_mountpointDS8k", VolumeConfig: map[string]interface{}{"Name": "u_vol", "PhysicalCapacity": fakePhysicalCapacity,
 			"Profile": fakeProfile, "StorageType": fakeDS8kStoragetType, "UsedCapacity": fakeUsedCapacity, "Wwn": "wwn", "attach-to": "node1",
 			"LogicalCapacity": fakeLogicalCapacity, "PoolName": "pool", "StorageName": "IBM.2107", "fstype": "ext4"}}

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -358,5 +358,5 @@ type RequestContext struct {
 
 type VolumeMountProperties struct {
 	WWN       string
-	LunNumber float64
+	LunNumber int
 }


### PR DESCRIPTION
change LunNumber from float64 to int.
LunNumber should be int, but after json.Marshal and json.UNmarshal it will become float64.
see https://stackoverflow.com/questions/39152481/unmarshaling-a-json-integer-to-an-empty-interface-results-in-wrong-type-assertio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/296)
<!-- Reviewable:end -->
