### PR TITLE
UB-1977 exclude the warning messages in multipath output

### DIFF
--- a/remote/mounter/block_device_utils/mpath.go
+++ b/remote/mounter/block_device_utils/mpath.go
@@ -111,6 +111,8 @@ func (b *blockDeviceUtils) mpathDevFullPath(dev string) string {
 func (b *blockDeviceUtils) DiscoverBySgInq(mpathOutput string, volumeWwn string) (string, error) {
 	defer b.logger.Trace(logs.DEBUG)()
 
+	mpathOutput = utils.ExcludeNoTargetPortGroupMessagesFromMultipathOutput(mpathOutput, b.logger)
+
 	scanner := bufio.NewScanner(strings.NewReader(mpathOutput))
 	// regex to find all dm-X line from IBM vendor.
 	// Note: searching "IBM" in the line also focus the search on IBM devices only and also eliminate the need to run sg_inq on faulty devices.

--- a/utils/mpath_test.go
+++ b/utils/mpath_test.go
@@ -79,7 +79,7 @@ size=20G features='1 queue_if_no_path' hwhandler='0' wp=rw
   '- 39:0:0:0 sdc 8:32 active ready running
 `
 
-var fakeMultipathOutputWithWarningsRemoved = `mpathj (36005076306ffd69d0000000000001004) dm-17 IBM     ,2145
+var fakeMultipathOutputWithWarningsExcluded = `mpathj (36005076306ffd69d0000000000001004) dm-17 IBM     ,2145
 size=1.0G features='1 queue_if_no_path' hwhandler='0' wp=rw
 |-+- policy='service-time 0' prio=0 status=enabled
 | '- 39:0:0:1 sde 8:64 failed faulty running
@@ -92,7 +92,7 @@ size=20G features='1 queue_if_no_path' hwhandler='0' wp=rw
 '-+- policy='service-time 0' prio=10 status=enabled
   '- 39:0:0:0 sdc 8:32 active ready running`
 
-var _ = FDescribe("scbe_mounter_test", func() {
+var _ = Describe("multipath_utils_test", func() {
 	var (
 		fakeExec *fakes.FakeExecutor
 	)
@@ -138,10 +138,10 @@ var _ = FDescribe("scbe_mounter_test", func() {
 
 	Context("ExcludeNoTargetPortGroupMessagesFromMultipathOutput", func() {
 
-		It("should get device names from multipath output", func() {
+		It("should exclude the warning messages from multipath output", func() {
 			logger := logs.GetLogger()
 			out := utils.ExcludeNoTargetPortGroupMessagesFromMultipathOutput(fakeMultipathOutputWithWarnings, logger)
-			Expect(out).To(Equal(fakeMultipathOutputWithWarningsRemoved))
+			Expect(out).To(Equal(fakeMultipathOutputWithWarningsExcluded))
 		})
 	})
 })

--- a/utils/mpath_test.go
+++ b/utils/mpath_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/IBM/ubiquity/fakes"
 	"github.com/IBM/ubiquity/utils"
+	"github.com/IBM/ubiquity/utils/logs"
 )
 
 const (
@@ -18,7 +19,7 @@ const (
 	fakeProfile          = "gold"
 )
 
-var fakeWwn = "6005076306ffd69d0000000000001004"
+var fakeWwn = "6005076306FFD69d0000000000001004"
 
 var fakeMultipathOutput = `
 mpathg (36005076306ffd69d0000000000001004) dm-14 IBM     ,2107900
@@ -35,7 +36,7 @@ size=2.0G features='1 queue_if_no_path' hwhandler='0' wp=rw
   ` + "`- 29:0:7:0 sdd 8:48 active ready running\n"
 
 var fakeMultipathOutputWithMultiplePathGroups = `
-mpathc (6005076306ffd69d0000000000001004) dm-4 IBM     ,2145
+mpathc (36005076306ffd69d0000000000001004) dm-4 IBM     ,2145
 size=1.0G features='0' hwhandler='0' wp=rw
 |-+- policy='service-time 0' prio=50 status=active
 | '- 43:0:0:3 sda 8:112 active ready running
@@ -50,7 +51,7 @@ size=1.0G features='1 queue_if_no_path' hwhandler='0' wp=rw
 `
 
 var fakeMultipathOutputWithDifferentSpaces = `
-mpathj (6005076306ffd69d0000000000001004) dm-27 IBM     ,2107900
+mpathj (36005076306ffd69d0000000000001004) dm-27 IBM     ,2107900
 size=1.0G features='0' hwhandler='0' wp=rw
 '-+- policy='service-time 0' prio=1 status=active
   |- 33:0:12:1 sdcp 69:208 active ready running
@@ -61,7 +62,37 @@ size=1.0G features='0' hwhandler='0' wp=rw
   '- 34:0:9:1  sdcq 69:224 active ready running
 `
 
-var _ = Describe("scbe_mounter_test", func() {
+var fakeMultipathOutputWithWarnings = `
+Apr 04 16:38:06 | sde: couldn't get target port group
+Apr 04 16:38:06 | sdd: couldn't get target port group
+mpathj (36005076306ffd69d0000000000001004) dm-17 IBM     ,2145
+size=1.0G features='1 queue_if_no_path' hwhandler='0' wp=rw
+|-+- policy='service-time 0' prio=0 status=enabled
+| '- 39:0:0:1 sde 8:64 failed faulty running
+'-+- policy='service-time 0' prio=0 status=enabled
+  '- 40:0:0:1 sdd 8:48 failed faulty running
+mpathi (3600507680c8701159800000000001af3) dm-14 IBM     ,2145
+size=20G features='1 queue_if_no_path' hwhandler='0' wp=rw
+|-+- policy='service-time 0' prio=50 status=active
+| '- 40:0:0:0 sdb 8:16 active ready running
+'-+- policy='service-time 0' prio=10 status=enabled
+  '- 39:0:0:0 sdc 8:32 active ready running
+`
+
+var fakeMultipathOutputWithWarningsRemoved = `mpathj (36005076306ffd69d0000000000001004) dm-17 IBM     ,2145
+size=1.0G features='1 queue_if_no_path' hwhandler='0' wp=rw
+|-+- policy='service-time 0' prio=0 status=enabled
+| '- 39:0:0:1 sde 8:64 failed faulty running
+'-+- policy='service-time 0' prio=0 status=enabled
+  '- 40:0:0:1 sdd 8:48 failed faulty running
+mpathi (3600507680c8701159800000000001af3) dm-14 IBM     ,2145
+size=20G features='1 queue_if_no_path' hwhandler='0' wp=rw
+|-+- policy='service-time 0' prio=50 status=active
+| '- 40:0:0:0 sdb 8:16 active ready running
+'-+- policy='service-time 0' prio=10 status=enabled
+  '- 39:0:0:0 sdc 8:32 active ready running`
+
+var _ = FDescribe("scbe_mounter_test", func() {
 	var (
 		fakeExec *fakes.FakeExecutor
 	)
@@ -94,6 +125,23 @@ var _ = Describe("scbe_mounter_test", func() {
 			Ω(err).ShouldNot(HaveOccurred())
 			Expect(devMapper).To(Equal("mpathj"))
 			Expect(devNames).To(Equal([]string{"sdcp", "sdcn", "sdco", "sdcr", "sdcs", "sdcq"}))
+		})
+
+		It("should get device names from multipath output with warning header", func() {
+			fakeExec.ExecuteWithTimeoutReturns([]byte(fakeMultipathOutputWithWarnings), nil)
+			_, devMapper, devNames, err := utils.GetMultipathOutputAndDeviceMapperAndDevice(fakeWwn, fakeExec)
+			Ω(err).ShouldNot(HaveOccurred())
+			Expect(devMapper).To(Equal("mpathj"))
+			Expect(devNames).To(Equal([]string{"sde", "sdd"}))
+		})
+	})
+
+	Context("ExcludeNoTargetPortGroupMessagesFromMultipathOutput", func() {
+
+		It("should get device names from multipath output", func() {
+			logger := logs.GetLogger()
+			out := utils.ExcludeNoTargetPortGroupMessagesFromMultipathOutput(fakeMultipathOutputWithWarnings, logger)
+			Expect(out).To(Equal(fakeMultipathOutputWithWarningsRemoved))
 		})
 	})
 })


### PR DESCRIPTION
The multipath output might print some warning messages if some devices are faulty, it has impact on the function isDeviceFaulty. I have no time to improve this fucntion, I will exclude these messages in 2.1 release.

Here is an example output:
```
Apr 04 16:13:40 | sde: couldn't get target port group
Apr 04 16:13:40 | sdd: couldn't get target port group
mpathj (3600507680c8701159800000000001af4) dm-17 IBM     ,2145            
size=1.0G features='1 queue_if_no_path' hwhandler='0' wp=rw
|-+- policy='service-time 0' prio=0 status=active
| `- 39:0:0:1 sde 8:64 failed faulty running
`-+- policy='service-time 0' prio=0 status=enabled
  `- 40:0:0:1 sdd 8:48 failed faulty running
mpathi (3600507680c8701159800000000001af3) dm-14 IBM     ,2145            
size=20G features='1 queue_if_no_path' hwhandler='0' wp=rw
|-+- policy='service-time 0' prio=50 status=active
| `- 40:0:0:0 sdb 8:16 active ready running
`-+- policy='service-time 0' prio=10 status=enabled
  `- 39:0:0:0 sdc 8:32 active ready running
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ibm/ubiquity/303)
<!-- Reviewable:end -->
