### PR TITLE
Parse multipath result from multipathd -k

### DIFF
--- a/fakes/fake_executor.go
+++ b/fakes/fake_executor.go
@@ -36,6 +36,21 @@ type FakeExecutor struct {
 		result1 []byte
 		result2 error
 	}
+	ExecuteInteractiveStub        func(string, []string, []string) ([]byte, error)
+	executeInteractiveMutex       sync.RWMutex
+	executeInteractiveArgsForCall []struct {
+		arg1 string
+		arg2 []string
+		arg3 []string
+	}
+	executeInteractiveReturns struct {
+		result1 []byte
+		result2 error
+	}
+	executeInteractiveReturnsOnCall map[int]struct {
+		result1 []byte
+		result2 error
+	}
 	ExecuteWithTimeoutStub        func(int, string, []string) ([]byte, error)
 	executeWithTimeoutMutex       sync.RWMutex
 	executeWithTimeoutArgsForCall []struct {
@@ -371,6 +386,81 @@ func (fake *FakeExecutor) ExecuteReturnsOnCall(i int, result1 []byte, result2 er
 		})
 	}
 	fake.executeReturnsOnCall[i] = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeExecutor) ExecuteInteractive(arg1 string, arg2 []string, arg3 []string) ([]byte, error) {
+	var arg2Copy []string
+	if arg2 != nil {
+		arg2Copy = make([]string, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.executeInteractiveMutex.Lock()
+	ret, specificReturn := fake.executeInteractiveReturnsOnCall[len(fake.executeInteractiveArgsForCall)]
+	fake.executeInteractiveArgsForCall = append(fake.executeInteractiveArgsForCall, struct {
+		arg1 string
+		arg2 []string
+		arg3 []string
+	}{arg1, arg2Copy, arg3Copy})
+	fake.recordInvocation("ExecuteInteractive", []interface{}{arg1, arg2Copy, arg3Copy})
+	fake.executeInteractiveMutex.Unlock()
+	if fake.ExecuteInteractiveStub != nil {
+		return fake.ExecuteInteractiveStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.executeInteractiveReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeExecutor) ExecuteInteractiveCallCount() int {
+	fake.executeInteractiveMutex.RLock()
+	defer fake.executeInteractiveMutex.RUnlock()
+	return len(fake.executeInteractiveArgsForCall)
+}
+
+func (fake *FakeExecutor) ExecuteInteractiveCalls(stub func(string, []string, []string) ([]byte, error)) {
+	fake.executeInteractiveMutex.Lock()
+	defer fake.executeInteractiveMutex.Unlock()
+	fake.ExecuteInteractiveStub = stub
+}
+
+func (fake *FakeExecutor) ExecuteInteractiveArgsForCall(i int) (string, []string, []string) {
+	fake.executeInteractiveMutex.RLock()
+	defer fake.executeInteractiveMutex.RUnlock()
+	argsForCall := fake.executeInteractiveArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeExecutor) ExecuteInteractiveReturns(result1 []byte, result2 error) {
+	fake.executeInteractiveMutex.Lock()
+	defer fake.executeInteractiveMutex.Unlock()
+	fake.ExecuteInteractiveStub = nil
+	fake.executeInteractiveReturns = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeExecutor) ExecuteInteractiveReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.executeInteractiveMutex.Lock()
+	defer fake.executeInteractiveMutex.Unlock()
+	fake.ExecuteInteractiveStub = nil
+	if fake.executeInteractiveReturnsOnCall == nil {
+		fake.executeInteractiveReturnsOnCall = make(map[int]struct {
+			result1 []byte
+			result2 error
+		})
+	}
+	fake.executeInteractiveReturnsOnCall[i] = struct {
 		result1 []byte
 		result2 error
 	}{result1, result2}
@@ -1424,6 +1514,8 @@ func (fake *FakeExecutor) Invocations() map[string][][]interface{} {
 	defer fake.evalSymlinksMutex.RUnlock()
 	fake.executeMutex.RLock()
 	defer fake.executeMutex.RUnlock()
+	fake.executeInteractiveMutex.RLock()
+	defer fake.executeInteractiveMutex.RUnlock()
 	fake.executeWithTimeoutMutex.RLock()
 	defer fake.executeWithTimeoutMutex.RUnlock()
 	fake.getDeviceForFileStatMutex.RLock()

--- a/utils/mpath_test.go
+++ b/utils/mpath_test.go
@@ -92,6 +92,112 @@ size=20G features='1 queue_if_no_path' hwhandler='0' wp=rw
 '-+- policy='service-time 0' prio=10 status=enabled
   '- 39:0:0:0 sdc 8:32 active ready running`
 
+var fakeMultipathOutputAllJson = `
+multipathd> list maps json
+{
+   "major_version": 0,
+   "minor_version": 1,
+   "maps": [{
+      "name" : "mpathp",
+      "uuid" : "360050768029b8168e000000000006247",
+      "sysfs" : "dm-3",
+      "failback" : "immediate",
+      "queueing" : "5 chk",
+      "paths" : 0,
+      "write_prot" : "rw",
+      "dm_st" : "active",
+      "features" : "0",
+      "hwhandler" : "0",
+      "action" : "create",
+      "path_faults" : 1,
+      "vend" : "IBM     ",
+      "prod" : "2145            ",
+      "rev" : "0000",
+      "switch_grp" : 0,
+      "map_loads" : 1,
+      "total_q_time" : 26,
+      "q_timeouts" : 1,
+      "path_groups": [{
+         "selector" : "round-robin 0",
+         "pri" : 0,
+         "dm_st" : "active",
+         "group" : 1,
+         "paths": [{
+            "dev" : "sdb",
+            "dev_t" : "8:16",
+            "dm_st" : "failed",
+            "dev_st" : "running",
+            "chk_st" : "faulty",
+            "checker" : "tur",
+            "pri" : 50,
+            "host_wwnn" : "[undef]",
+            "target_wwnn" : "iqn.1986-03.com.ibm:2145.v7k60.node1",
+            "host_wwpn" : "[undef]",
+            "target_wwpn" : "[undef]",
+            "host_adapter" : "9.115.240.253"
+         }]
+      }]
+   }]
+}
+multipathd> exit
+`
+
+var fakeMultipathOutputJson = `
+multipathd> list maps json
+{
+   "major_version": 0,
+   "minor_version": 1,
+   "map": {
+      "name" : "mpathp",
+      "uuid" : "360050768029b8168e000000000006247",
+      "sysfs" : "dm-3",
+      "failback" : "immediate",
+      "queueing" : "5 chk",
+      "paths" : 0,
+      "write_prot" : "rw",
+      "dm_st" : "active",
+      "features" : "0",
+      "hwhandler" : "0",
+      "action" : "create",
+      "path_faults" : 1,
+      "vend" : "IBM     ",
+      "prod" : "2145            ",
+      "rev" : "0000",
+      "switch_grp" : 0,
+      "map_loads" : 1,
+      "total_q_time" : 26,
+      "q_timeouts" : 1,
+      "path_groups": [{
+         "selector" : "round-robin 0",
+         "pri" : 0,
+         "dm_st" : "active",
+         "group" : 1,
+         "paths": [{
+            "dev" : "sdb",
+            "dev_t" : "8:16",
+            "dm_st" : "failed",
+            "dev_st" : "running",
+            "chk_st" : "faulty",
+            "checker" : "tur",
+            "pri" : 50,
+            "host_wwnn" : "[undef]",
+            "target_wwnn" : "iqn.1986-03.com.ibm:2145.v7k60.node1",
+            "host_wwpn" : "[undef]",
+            "target_wwpn" : "[undef]",
+            "host_adapter" : "9.115.240.253"
+         }]
+      }]
+   }
+}
+multipathd> exit
+`
+
+var fakeMultipathNameUuidpair = `
+multipathd> list maps json
+mpathp,360050768029b8168e000000000006247
+multipathd> exit
+`
+
 var _ = Describe("multipath_utils_test", func() {
 	var (
 		fakeExec *fakes.FakeExecutor
@@ -142,6 +248,49 @@ var _ = Describe("multipath_utils_test", func() {
 			logger := logs.GetLogger()
 			out := utils.ExcludeNoTargetPortGroupMessagesFromMultipathOutput(fakeMultipathOutputWithWarnings, logger)
 			Expect(out).To(Equal(fakeMultipathOutputWithWarningsExcluded))
+		})
+	})
+
+	Context("GetMultipathOutputAll", func() {
+
+		It("should get correct json response and unmarshal to MultipathOutputAll", func() {
+			fakeExec.ExecuteInteractiveReturns([]byte(fakeMultipathOutputAllJson), nil)
+			out, err := utils.GetMultipathOutputAll(fakeExec)
+			Ω(err).ShouldNot(HaveOccurred())
+			Expect(out.Maps).To(HaveLen(1))
+			mpath := out.Maps[0]
+			Expect(mpath.PathGroups).To(HaveLen(1))
+			pg := mpath.PathGroups[0]
+			Expect(pg.Paths).To(HaveLen(1))
+			path := pg.Paths[0]
+			Expect(path.Dev).To(Equal("sdb"))
+		})
+	})
+
+	Context("GetMultipathOutput", func() {
+
+		It("should get correct json response and unmarshal to MultipathOutput", func() {
+			fakeExec.ExecuteInteractiveReturns([]byte(fakeMultipathOutputJson), nil)
+			out, err := utils.GetMultipathOutput("mpathp", fakeExec)
+			Ω(err).ShouldNot(HaveOccurred())
+			Expect(out.Map).NotTo(BeNil())
+			mpath := out.Map
+			Expect(mpath.PathGroups).To(HaveLen(1))
+			pg := mpath.PathGroups[0]
+			Expect(pg.Paths).To(HaveLen(1))
+			path := pg.Paths[0]
+			Expect(path.Dev).To(Equal("sdb"))
+		})
+	})
+
+	Context("GetMultipathNameUuidpair", func() {
+
+		It("should return correct name uuid pair", func() {
+			fakeExec.ExecuteInteractiveReturns([]byte(fakeMultipathNameUuidpair), nil)
+			pairs, err := utils.GetMultipathNameUuidpair(fakeExec)
+			Ω(err).ShouldNot(HaveOccurred())
+			Expect(pairs).To(HaveLen(1))
+			Expect(pairs[0]).To(Equal("mpathp,360050768029b8168e000000000006247"))
 		})
 	})
 })

--- a/utils/resources.go
+++ b/utils/resources.go
@@ -1,0 +1,84 @@
+package utils
+
+/*
+Example multipath output:
+{
+   "major_version": 0,
+   "minor_version": 1,
+   "maps": [{
+      "name" : "mpathp",
+      "uuid" : "360050768029b8168e000000000006247",
+      "sysfs" : "dm-3",
+      "failback" : "immediate",
+      "queueing" : "5 chk",
+      "paths" : 0,
+      "write_prot" : "rw",
+      "dm_st" : "active",
+      "features" : "0",
+      "hwhandler" : "0",
+      "action" : "create",
+      "path_faults" : 1,
+      "vend" : "IBM     ",
+      "prod" : "2145            ",
+      "rev" : "0000",
+      "switch_grp" : 0,
+      "map_loads" : 1,
+      "total_q_time" : 26,
+      "q_timeouts" : 1,
+      "path_groups": [{
+         "selector" : "round-robin 0",
+         "pri" : 0,
+         "dm_st" : "active",
+         "group" : 1,
+         "paths": [{
+            "dev" : "sdb",
+            "dev_t" : "8:16",
+            "dm_st" : "failed",
+            "dev_st" : "running",
+            "chk_st" : "faulty",
+            "checker" : "tur",
+            "pri" : 50,
+            "host_wwnn" : "[undef]",
+            "target_wwnn" : "iqn.1986-03.com.ibm:2145.v7k60.node1",
+            "host_wwpn" : "[undef]",
+            "target_wwpn" : "[undef]",
+            "host_adapter" : "9.115.240.253"
+         }]
+      }]
+   }]
+}
+*/
+
+type MultipathOutputAll struct {
+	Maps []*MultipathDevice `json:"maps"`
+}
+
+type MultipathOutput struct {
+	Map *MultipathDevice `json:"map"`
+}
+
+type MultipathDevice struct {
+	Name       string                      `json:"name"`
+	Uuid       string                      `json:"uuid"`
+	Sysfs      string                      `json:"sysfs"`
+	PathFaults int                         `json:"path_faults"`
+	Vend       string                      `json:"vend"`
+	Prod       string                      `json:"prod"`
+	PathGroups []*MultipathDevicePathGroup `json:"path_groups"`
+}
+
+type MultipathDevicePathGroup struct {
+	Selector string                 `json:"selector"`
+	Pri      int                    `json:"pri"`
+	DmSt     string                 `json:"dm_st"`
+	Group    int                    `json:"group"`
+	Paths    []*MultipathDevicePath `json:"paths"`
+}
+
+type MultipathDevicePath struct {
+	Dev   string `json:"dev"`
+	DevT  string `json:"dev_t"`
+	DmSt  string `json:"dm_st"`
+	DevSt string `json:"dev_st"`
+	ChkSt string `json:"chk_st"`
+}


### PR DESCRIPTION
multipathd -k is a powerful interactive shell to print multipath information, see [here](https://www.systutorials.com/docs/linux/man/8-multipathd/) for details.
We can use it to print the multipath output in json, or just print the name and uuid in this way: "mpatha,360050768029b8168e000000000006247"